### PR TITLE
Fix url for search engine spiders

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 module.exports = {
   title: 'Syscoin Docs',
   tagline: 'Documentation for the buidlers!',
-  url: 'https://Syscoin.github.io/sys-docs/',
+  url: 'https://Syscoin.github.io/sys-docs',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
URLs in results of search engines end up presenting a double trailing slash;
"https://Syscoin.github.io/sys-docs//..."
This leads to 404.

Removing trailing slash from url parameter in docusaurus.config.js.