### PR TITLE
docs: add auto-generated syscoin RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/syscoin/_category_.json
+++ b/docs/cli/syscoin/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Syscoin",
+  "position": 11
+}

--- a/docs/cli/syscoin/assetallocationverifyzdag.mdx
+++ b/docs/cli/syscoin/assetallocationverifyzdag.mdx
@@ -1,0 +1,45 @@
+---
+title: assetallocationverifyzdag
+sidebar_label: assetallocationverifyzdag
+description: "Syscoin Core CLI reference: assetallocationverifyzdag"
+---
+
+# `assetallocationverifyzdag`
+
+Show status as it pertains to any current Z-DAG conflicts or warnings related to a ZDAG transaction.
+Return value is in the status field and can represent 3 levels(0, 1 or 2)
+Level -1 means not found, not a ZDAG transaction, perhaps it is already confirmed.
+Level 0 means OK.
+Level 1 means warning (checked that in the mempool there are more spending balances than current POW sender balance). An active stance should be taken and perhaps a deeper analysis as to potential conflicts related to the sender.
+Level 2 means an active double spend was found and any depending asset allocation sends are also flagged as dangerous and should wait for POW confirmation before proceeding.
+
+## Synopsis
+
+```
+assetallocationverifyzdag "txid"
+```
+
+## Arguments
+
+```
+1. txid    (string, required) The transaction id of the ZDAG transaction.
+```
+
+## Result
+
+```
+{                  (json object)
+  "status" : n     (numeric) The status level of the transaction
+}
+```
+
+## Examples
+
+```
+> syscoin-cli assetallocationverifyzdag "txid"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "assetallocationverifyzdag", "params": ["txid"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/assetrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/assetrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/getnevmblobdata.mdx
+++ b/docs/cli/syscoin/getnevmblobdata.mdx
@@ -1,0 +1,33 @@
+---
+title: getnevmblobdata
+sidebar_label: getnevmblobdata
+description: "Syscoin Core CLI reference: getnevmblobdata"
+---
+
+# `getnevmblobdata`
+
+Return NEVM blob information and status from a version hash.
+
+## Synopsis
+
+```
+getnevmblobdata "versionhash_or_txid" ( getdata )
+```
+
+## Arguments
+
+```
+1. versionhash_or_txid    (string, required) The version hash or txid of the NEVM blob
+2. getdata                (boolean, optional) Optional, retrieve the blob data
+```
+
+## Examples
+
+```
+> syscoin-cli getnevmblobdata 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getnevmblobdata", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/nevmrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/nevmrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/getnevmblockchaininfo.mdx
+++ b/docs/cli/syscoin/getnevmblockchaininfo.mdx
@@ -1,0 +1,41 @@
+---
+title: getnevmblockchaininfo
+sidebar_label: getnevmblockchaininfo
+description: "Syscoin Core CLI reference: getnevmblockchaininfo"
+---
+
+# `getnevmblockchaininfo`
+
+Return NEVM blockchain information and status.
+
+## Synopsis
+
+```
+getnevmblockchaininfo
+```
+
+## Result
+
+```
+{                                 (json object)
+  "bestblockhash" : "hex",        (string) The tip of the NEVM blockchain
+  "previousblockhash" : "hex",    (string) The hash of the previous block
+  "txroot" : "hex",               (string) Transaction root of the current tip
+  "receiptroot" : "hex",          (string) Receipt root of the current tip
+  "blocksize" : n,                (numeric) Serialized NEVM block size. 0 means it has been pruned.
+  "height" : n,                   (numeric) The current NEVM blockchain height
+  "commandline" : "str",          (string) The NEVM command line parameters used to pass through to sysgeth
+  "status" : "str"                (string) The NEVM status, online or offline
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getnevmblockchaininfo 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getnevmblockchaininfo", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/nevmrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/nevmrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/listnevmblobdata.mdx
+++ b/docs/cli/syscoin/listnevmblobdata.mdx
@@ -1,0 +1,58 @@
+---
+title: listnevmblobdata
+sidebar_label: listnevmblobdata
+description: "Syscoin Core CLI reference: listnevmblobdata"
+---
+
+# `listnevmblobdata`
+
+Scan through all blobs or get blob statistics.
+
+## Synopsis
+
+```
+listnevmblobdata ( count from {"stats":bool} )
+```
+
+## Arguments
+
+```
+1. count                 (numeric, optional, default=10) The number of results to return.
+2. from                  (numeric, optional, default=0) The number of results to skip.
+3. options               (json object, optional) A json object with options to filter results.
+     {
+       "stats": bool,    (boolean, optional) Return statistics for all blobs (ignores count/from)
+     }
+```
+
+## Result
+
+```
+[                             (json array)
+  {                           (json object)
+    "versionhash" : "hex",    (string) The version hash of the NEVM blob
+    "datasize" : n,           (numeric) Size of data blob in bytes
+    "txid" : n,               (numeric) Transaction ID of the blob tx
+    "mtp" : n                 (numeric) Median timestamp of the blob
+  },
+  {                           (json object)
+    "total_blobs" : n,        (numeric) Total number of blobs
+    "total_size" : n,         (numeric) Total size of all blobs in bytes
+    "oldest_mpt" : n,         (numeric) Median timestamp of the oldest blob
+    "newest_mpt" : n          (numeric) Median timestamp of the newest blob
+  },
+  ...
+]
+```
+
+## Examples
+
+```
+> syscoin-cli listnevmblobdata 0
+> syscoin-cli listnevmblobdata 10 10
+> syscoin-cli listnevmblobdata 0 0 '{"stats":true}'
+```
+
+---
+
+*Source: [src/services/rpc/nevmrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/nevmrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/mnauth.mdx
+++ b/docs/cli/syscoin/mnauth.mdx
@@ -1,0 +1,40 @@
+---
+title: mnauth
+sidebar_label: mnauth
+description: "Syscoin Core CLI reference: mnauth"
+---
+
+# `mnauth`
+
+Override MNAUTH processing results for the specified node with a user provided data (-regtest only).
+
+## Synopsis
+
+```
+mnauth nodeId "proTxHash" "publicKey"
+```
+
+## Arguments
+
+```
+1. nodeId       (numeric, required) Internal peer id of the node the mock data gets added to
+2. proTxHash    (string, required) The authenticated proTxHash as hex string
+3. publicKey    (string, required) The authenticated public key as hex string
+```
+
+## Result
+
+```
+true|false    (boolean) If MNAUTH was overridden or not.
+```
+
+## Examples
+
+```
+Override MNAUTH processing
+> syscoin-cli mnauth "nodeId "proTxHash" "publicKey""
+```
+
+---
+
+*Source: [src/rpc/node.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/node.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/mnsync.mdx
+++ b/docs/cli/syscoin/mnsync.mdx
@@ -1,0 +1,32 @@
+---
+title: mnsync
+sidebar_label: mnsync
+description: "Syscoin Core CLI reference: mnsync"
+---
+
+# `mnsync`
+
+Returns the sync status, updates to the next step or resets it entirely.
+
+## Synopsis
+
+```
+mnsync "command"
+```
+
+## Arguments
+
+```
+1. command    (string, required) The command to issue (status|next|reset)
+```
+
+## Examples
+
+```
+> syscoin-cli mnsync status
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "mnsync", "params": [status]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/node.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/node.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/spork.mdx
+++ b/docs/cli/syscoin/spork.mdx
@@ -1,0 +1,35 @@
+---
+title: spork
+sidebar_label: spork
+description: "Syscoin Core CLI reference: spork"
+---
+
+# `spork`
+
+Shows or updates the value of the specific spork. Requires "-sporkkey" to be set to sign the message for updating.
+
+## Synopsis
+
+```
+spork "command" ( value )
+```
+
+## Arguments
+
+```
+1. command    (string, required) "show" to show all current spork values, "active" to show which sporks are active or the name of the spork to update
+2. value      (numeric, optional) The new desired value of the spork if updating
+```
+
+## Examples
+
+```
+> syscoin-cli spork SPORK_9_NEW_SIGS 4070908800
+> syscoin-cli spork show
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "spork", "params": ["SPORK_9_NEW_SIGS", 4070908800]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "spork", "params": ["show"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/node.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/node.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/syscoincheckmint.mdx
+++ b/docs/cli/syscoin/syscoincheckmint.mdx
@@ -1,0 +1,40 @@
+---
+title: syscoincheckmint
+sidebar_label: syscoincheckmint
+description: "Syscoin Core CLI reference: syscoincheckmint"
+---
+
+# `syscoincheckmint`
+
+Get the Syscoin mint transaction by looking up using NEVM tx hash (This is no the txid, it is the sha3 of the transaction bytes value).
+
+## Synopsis
+
+```
+syscoincheckmint "nevm_txhash"
+```
+
+## Arguments
+
+```
+1. nevm_txhash    (string, required) NEVM Tx Hash used to burn funds to move to Syscoin.
+```
+
+## Result
+
+```
+{                    (json object)
+  "txid" : "hex"     (string) The transaction id
+}
+```
+
+## Examples
+
+```
+> syscoin-cli syscoincheckmint d8ac75c7b4084c85a89d6e28219ff162661efb8b794d4b66e6e9ea52b4139b10
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "syscoincheckmint", "params": [d8ac75c7b4084c85a89d6e28219ff162661efb8b794d4b66e6e9ea52b4139b10]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/assetrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/assetrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/syscoindecoderawtransaction.mdx
+++ b/docs/cli/syscoin/syscoindecoderawtransaction.mdx
@@ -1,0 +1,50 @@
+---
+title: syscoindecoderawtransaction
+sidebar_label: syscoindecoderawtransaction
+description: "Syscoin Core CLI reference: syscoindecoderawtransaction"
+---
+
+# `syscoindecoderawtransaction`
+
+Decode raw syscoin transaction (serialized, hex-encoded) and display information pertaining to the service that is included in the transactiion data output(OP_RETURN)
+
+## Synopsis
+
+```
+syscoindecoderawtransaction "hexstring"
+```
+
+## Arguments
+
+```
+1. hexstring    (string, required) The transaction hex string.
+```
+
+## Result
+
+```
+{                                (json object)
+  "txtype" : "str",              (string) The syscoin transaction type
+  "txid" : "hex",                (string) The transaction id
+  "blockhash" : "hex",           (string) Block confirming the transaction, if any
+  "allocations" : [              (json array) (array of json receiver objects)
+    {                            (json object, optional)
+      "asset_guid" : n,          (numeric) Asset guid
+      "amount" : n               (numeric) Value
+    },
+    ...
+  ],
+  "nevm_destination" : "str"     (string, optional) NEVM destination address
+}
+```
+
+## Examples
+
+```
+> syscoin-cli syscoindecoderawtransaction "hexstring"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "syscoindecoderawtransaction", "params": ["hexstring"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/assetrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/assetrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/syscoingetspvproof.mdx
+++ b/docs/cli/syscoin/syscoingetspvproof.mdx
@@ -1,0 +1,26 @@
+---
+title: syscoingetspvproof
+sidebar_label: syscoingetspvproof
+description: "Syscoin Core CLI reference: syscoingetspvproof"
+---
+
+# `syscoingetspvproof`
+
+Returns SPV proof for use with inter-chain transfers.
+
+## Synopsis
+
+```
+syscoingetspvproof "txid" ( "blockhash" )
+```
+
+## Arguments
+
+```
+1. txid         (string, required) A transaction that is in the block
+2. blockhash    (string, optional) If specified, looks for txid in the block with this hash
+```
+
+---
+
+*Source: [src/services/rpc/nevmrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/nevmrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/syscoingettxroots.mdx
+++ b/docs/cli/syscoin/syscoingettxroots.mdx
@@ -1,0 +1,41 @@
+---
+title: syscoingettxroots
+sidebar_label: syscoingettxroots
+description: "Syscoin Core CLI reference: syscoingettxroots"
+---
+
+# `syscoingettxroots`
+
+Get NEVM transaction and receipt roots based on block hash.
+
+## Synopsis
+
+```
+syscoingettxroots "blockhash"
+```
+
+## Arguments
+
+```
+1. blockhash    (string, required) The block hash to lookup.
+```
+
+## Result
+
+```
+{                           (json object)
+  "txroot" : "hex",         (string) The transaction merkle root
+  "receiptroot" : "hex"     (string) The receipt merkle root
+}
+```
+
+## Examples
+
+```
+> syscoin-cli syscoingettxroots 0xd8ac75c7b4084c85a89d6e28219ff162661efb8b794d4b66e6e9ea52b4139b10
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "syscoingettxroots", "params": [0xd8ac75c7b4084c85a89d6e28219ff162661efb8b794d4b66e6e9ea52b4139b10]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/assetrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/assetrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/syscoinstartgeth.mdx
+++ b/docs/cli/syscoin/syscoinstartgeth.mdx
@@ -1,0 +1,34 @@
+---
+title: syscoinstartgeth
+sidebar_label: syscoinstartgeth
+description: "Syscoin Core CLI reference: syscoinstartgeth"
+---
+
+# `syscoinstartgeth`
+
+Starts Geth.
+
+## Synopsis
+
+```
+syscoinstartgeth
+```
+
+## Result
+
+```
+{                      (json object)
+  "status" : "str"     (string) Result
+}
+```
+
+## Examples
+
+```
+> syscoin-cli syscoinstartgeth 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "syscoinstartgeth", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/nevmrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/nevmrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoin/syscoinstopgeth.mdx
+++ b/docs/cli/syscoin/syscoinstopgeth.mdx
@@ -1,0 +1,34 @@
+---
+title: syscoinstopgeth
+sidebar_label: syscoinstopgeth
+description: "Syscoin Core CLI reference: syscoinstopgeth"
+---
+
+# `syscoinstopgeth`
+
+Stops Geth from running.
+
+## Synopsis
+
+```
+syscoinstopgeth
+```
+
+## Result
+
+```
+{                      (json object)
+  "status" : "str"     (string) Result
+}
+```
+
+## Examples
+
+```
+> syscoin-cli syscoinstopgeth 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "syscoinstopgeth", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/nevmrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/nevmrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*


### PR DESCRIPTION
Adds 13 Syscoin-category RPC reference pages under `docs/cli/syscoin/`,
auto-generated from `syscoin-cli help` against Syscoin Core 5.0.5.

Second slice of the CLI reference rollout, following the wallet category.
The Syscoin category is particularly worth documenting locally. These
are Syscoin-distinctive RPCs with no Bitcoin Core equivalent, so they
can't be deferred to upstream docs.