### PR TITLE
docs: add auto-generated syscoinwallet RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/syscoinwallet/_category_.json
+++ b/docs/cli/syscoinwallet/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Syscoin Wallet",
+  "position": 12
+}

--- a/docs/cli/syscoinwallet/getauxblock.mdx
+++ b/docs/cli/syscoinwallet/getauxblock.mdx
@@ -1,0 +1,38 @@
+---
+title: getauxblock
+sidebar_label: getauxblock
+description: "Syscoin Core CLI reference: getauxblock"
+---
+
+# `getauxblock`
+
+Creates or submits a merge-mined block.
+
+Without arguments, creates a new block and returns information
+required to merge-mine it.  With arguments, submits a solved
+auxpow for a previously returned block.
+
+## Synopsis
+
+```
+getauxblock ( "hash" "auxpow" )
+```
+
+## Arguments
+
+```
+1. hash      (string, optional) Hash of the block to submit
+2. auxpow    (string, optional) Serialised auxpow found
+```
+
+## Examples
+
+```
+> syscoin-cli getauxblock 
+> syscoin-cli getauxblock "hash" "serialised auxpow"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getauxblock", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/wallet/nevmwalletrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/wallet/nevmwalletrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoinwallet/signmessagebech32.mdx
+++ b/docs/cli/syscoinwallet/signmessagebech32.mdx
@@ -1,0 +1,46 @@
+---
+title: signmessagebech32
+sidebar_label: signmessagebech32
+description: "Syscoin Core CLI reference: signmessagebech32"
+---
+
+# `signmessagebech32`
+
+Sign a message with the private key of an address (p2pkh or p2wpkh)
+Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
+
+## Synopsis
+
+```
+signmessagebech32 "address" "message"
+```
+
+## Arguments
+
+```
+1. address    (string, required) The syscoin address to use for the private key.
+2. message    (string, required) Message to sign.
+```
+
+## Result
+
+```
+"str"    (string) The signature of the message encoded in base 64
+```
+
+## Examples
+
+```
+Unlock the wallet for 30 seconds
+> syscoin-cli walletpassphrase "mypassphrase" 30
+
+Create the signature
+> syscoin-cli signmessagebech32 "1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX" "message"
+
+As a JSON-RPC signmessagebech32
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "signmessagebech32", "params": ["1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX", "message"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoinwallet/syscoincreatenevmblob.mdx
+++ b/docs/cli/syscoinwallet/syscoincreatenevmblob.mdx
@@ -1,0 +1,39 @@
+---
+title: syscoincreatenevmblob
+sidebar_label: syscoincreatenevmblob
+description: "Syscoin Core CLI reference: syscoincreatenevmblob"
+---
+
+# `syscoincreatenevmblob`
+
+Create NEVM blob data used by rollups
+
+## Synopsis
+
+```
+syscoincreatenevmblob "data" ( overwrite_existing conf_target "estimate_mode" fee_rate )
+```
+
+## Arguments
+
+```
+1. data                  (string, required) blob in hex
+2. overwrite_existing    (boolean, optional, default=true) true to overwrite an existing blob if it exists, false to return versionhash of data on duplicate.
+3. conf_target           (numeric, optional, default=wallet -txconfirmtarget) Confirmation target in blocks
+4. estimate_mode         (string, optional, default="unset") The fee estimate mode, must be one of (case insensitive):
+                         "unset"
+                         "economical"
+                         "conservative"
+5. fee_rate              (numeric or string, optional, default=not set, fall back to wallet fee estimation) Specify a fee rate in sat/vB.
+```
+
+## Examples
+
+```
+> syscoin-cli syscoincreatenevmblob "data"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "syscoincreatenevmblob", "params": ["data"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/wallet/nevmwalletrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/wallet/nevmwalletrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/syscoinwallet/syscoincreaterawnevmblob.mdx
+++ b/docs/cli/syscoinwallet/syscoincreaterawnevmblob.mdx
@@ -1,0 +1,39 @@
+---
+title: syscoincreaterawnevmblob
+sidebar_label: syscoincreaterawnevmblob
+description: "Syscoin Core CLI reference: syscoincreaterawnevmblob"
+---
+
+# `syscoincreaterawnevmblob`
+
+Create NEVM blob data used by rollups via a custom raw parameters
+
+## Synopsis
+
+```
+syscoincreaterawnevmblob "versionhash" "data" ( conf_target "estimate_mode" fee_rate )
+```
+
+## Arguments
+
+```
+1. versionhash      (string, required) Version hash of the blob
+2. data             (string, required) data in hex
+3. conf_target      (numeric, optional, default=wallet -txconfirmtarget) Confirmation target in blocks
+4. estimate_mode    (string, optional, default="unset") The fee estimate mode, must be one of (case insensitive):
+                    "unset"
+                    "economical"
+                    "conservative"
+5. fee_rate         (numeric or string, optional, default=not set, fall back to wallet fee estimation) Specify a fee rate in sat/vB.
+```
+
+## Examples
+
+```
+> syscoin-cli syscoincreaterawnevmblob "versionhash" "data" 6 economical 25
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "syscoincreaterawnevmblob", "params": ["versionhash" "data" 6 economical 25]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/services/rpc/wallet/nevmwalletrpc.cpp](https://github.com/syscoin/syscoin/blob/master/src/services/rpc/wallet/nevmwalletrpc.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*


### PR DESCRIPTION
Adds 4 Syscoinwallet-category RPC reference pages under
`docs/cli/syscoinwallet/`, auto-generated from `syscoin-cli help` against
Syscoin Core 5.0.5.

Third slice of the CLI reference rollout, complementing the wallet
(general) and syscoin (non-wallet) categories already shipped. The
Syscoinwallet category contains Syscoin-distinctive wallet RPCs. None
have Bitcoin Core equivalents, so they can't be deferred to upstream
docs.