### PR TITLE
docs: add auto-generated evo RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/evo/_category_.json
+++ b/docs/cli/evo/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Evo",
+  "position": 13
+}

--- a/docs/cli/evo/bls_fromsecret.mdx
+++ b/docs/cli/evo/bls_fromsecret.mdx
@@ -1,0 +1,33 @@
+---
+title: bls_fromsecret
+sidebar_label: bls_fromsecret
+description: "Syscoin Core CLI reference: bls_fromsecret"
+---
+
+# `bls_fromsecret`
+
+Parses a BLS secret key and returns the secret/public key pair.
+
+## Synopsis
+
+```
+bls_fromsecret "secret" ( legacy )
+```
+
+## Arguments
+
+```
+1. secret    (string, required) The BLS secret key.
+2. legacy    (boolean, optional, default=false) Use legacy BLS scheme
+```
+
+## Examples
+
+```
+> syscoin-cli bls_fromsecret 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "bls_fromsecret", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/bls_generate.mdx
+++ b/docs/cli/evo/bls_generate.mdx
@@ -1,0 +1,32 @@
+---
+title: bls_generate
+sidebar_label: bls_generate
+description: "Syscoin Core CLI reference: bls_generate"
+---
+
+# `bls_generate`
+
+Returns a BLS secret/public key pair.
+
+## Synopsis
+
+```
+bls_generate ( legacy )
+```
+
+## Arguments
+
+```
+1. legacy    (boolean, optional, default=false) Use legacy BLS scheme
+```
+
+## Examples
+
+```
+> syscoin-cli bls_generate 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "bls_generate", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/getbestchainlock.mdx
+++ b/docs/cli/evo/getbestchainlock.mdx
@@ -1,0 +1,38 @@
+---
+title: getbestchainlock
+sidebar_label: getbestchainlock
+description: "Syscoin Core CLI reference: getbestchainlock"
+---
+
+# `getbestchainlock`
+
+Returns information about the best ChainLock. Throws an error if there is no known ChainLock yet.
+
+## Synopsis
+
+```
+getbestchainlock
+```
+
+## Result
+
+```
+{                                (json object)
+  "blockhash" : "hex",           (string) The block hash hex-encoded
+  "height" : n,                  (numeric) The block height or index
+  "signature" : "hex",           (string) The ChainLock's BLS signature
+  "signers" : "hex",             (string) The ChainLock's quorum signers
+  "known_block" : true|false     (boolean) True if the block is known by our node
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getbestchainlock 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getbestchainlock", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/gettxchainlocks.mdx
+++ b/docs/cli/evo/gettxchainlocks.mdx
@@ -1,0 +1,49 @@
+---
+title: gettxchainlocks
+sidebar_label: gettxchainlocks
+description: "Syscoin Core CLI reference: gettxchainlocks"
+---
+
+# `gettxchainlocks`
+
+Returns the block height at which each transaction was mined, and indicates whether it is in the mempool, ChainLocked, or neither.
+
+## Synopsis
+
+```
+gettxchainlocks ["txid",...]
+```
+
+## Arguments
+
+```
+1. txids          (json array, required) The transaction ids (no more than 100)
+     [
+       "txid",    (string) A transaction hash
+       ...
+     ]
+```
+
+## Result
+
+```
+[                                (json array) Response is an array with the same size as the input txids
+  {                              (json object)
+    "height" : n,                (numeric) The block height
+    "chainlock" : true|false,    (boolean) The state of the corresponding block ChainLock
+    "mempool" : true|false       (boolean) Mempool status for the transaction
+  },
+  ...
+]
+```
+
+## Examples
+
+```
+> syscoin-cli gettxchainlocks '["mytxid",...]'
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gettxchainlocks", "params": [["mytxid",...]]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/protx_info.mdx
+++ b/docs/cli/evo/protx_info.mdx
@@ -1,0 +1,32 @@
+---
+title: protx_info
+sidebar_label: protx_info
+description: "Syscoin Core CLI reference: protx_info"
+---
+
+# `protx_info`
+
+Returns detailed information about a deterministic masternode.
+
+## Synopsis
+
+```
+protx_info "proTxHash"
+```
+
+## Arguments
+
+```
+1. proTxHash    (string, required) The hash of the initial ProRegTx.
+```
+
+## Examples
+
+```
+> syscoin-cli protx_info 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_info", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/protx_list.mdx
+++ b/docs/cli/evo/protx_list.mdx
@@ -1,0 +1,40 @@
+---
+title: protx_list
+sidebar_label: protx_list
+description: "Syscoin Core CLI reference: protx_list"
+---
+
+# `protx_list`
+
+Lists all ProTxs on-chain, depending on the given type.
+This will also include ProTx which failed PoSe verification.
+
+## Synopsis
+
+```
+protx_list ( "type" detailed height )
+```
+
+## Arguments
+
+```
+1. type        (string, optional, default="registered") 
+               Available types:
+               registered   - List all ProTx which are registered at the given chain height.
+               This will also include ProTx which failed PoSe verification.
+               valid        - List only ProTx which are active/valid at the given chain height.
+               
+2. detailed    (boolean, optional, default=false) If true, only the hashes of the ProTx will be returned.
+3. height      (numeric, optional) Height to look for ProTx transactions, if not specified defaults to current chain-tip
+```
+
+## Examples
+
+```
+> syscoin-cli protx_list registered true
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_list", "params": ["registered", true]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_dkgsimerror.mdx
+++ b/docs/cli/evo/quorum_dkgsimerror.mdx
@@ -1,0 +1,43 @@
+---
+title: quorum_dkgsimerror
+sidebar_label: quorum_dkgsimerror
+description: "Syscoin Core CLI reference: quorum_dkgsimerror"
+---
+
+# `quorum_dkgsimerror`
+
+This enables simulation of errors and malicious behaviour in the DKG. Do NOT use this on mainnet
+as you will get yourself very likely PoSe banned for this.
+
+## Synopsis
+
+```
+quorum_dkgsimerror "type" rate
+```
+
+## Arguments
+
+```
+1. type    (string, required) Error type.
+           Supported error types:
+           - contribution-omit
+           - contribution-lie
+           - complain-lie
+           - justify-lie
+           - justify-omit
+           - commit-omit
+           - commit-lie
+           
+2. rate    (numeric, required) Rate at which to simulate this error type.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_dkgsimerror contribution-omit 1
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_dkgsimerror", "params": ["contribution-omit", 1]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_dkgstatus.mdx
+++ b/docs/cli/evo/quorum_dkgstatus.mdx
@@ -1,0 +1,33 @@
+---
+title: quorum_dkgstatus
+sidebar_label: quorum_dkgstatus
+description: "Syscoin Core CLI reference: quorum_dkgstatus"
+---
+
+# `quorum_dkgstatus`
+
+Return the status of the current DKG process.
+
+## Synopsis
+
+```
+quorum_dkgstatus ( detail_level )
+```
+
+## Arguments
+
+```
+1. detail_level    (numeric, optional, default=0) Detail level of output.
+                   0=Only show counts. 1=Show member indexes. 2=Show member's ProTxHashes.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_dkgstatus 0
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_dkgstatus", "params": [0]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_getrecsig.mdx
+++ b/docs/cli/evo/quorum_getrecsig.mdx
@@ -1,0 +1,34 @@
+---
+title: quorum_getrecsig
+sidebar_label: quorum_getrecsig
+description: "Syscoin Core CLI reference: quorum_getrecsig"
+---
+
+# `quorum_getrecsig`
+
+Get a recovered signature.
+
+## Synopsis
+
+```
+quorum_getrecsig "id" "msgHash"
+```
+
+## Arguments
+
+```
+1. id         (string, required) Request id.
+              
+2. msgHash    (string, required) Message hash.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_getrecsig 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_getrecsig", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_hasrecsig.mdx
+++ b/docs/cli/evo/quorum_hasrecsig.mdx
@@ -1,0 +1,34 @@
+---
+title: quorum_hasrecsig
+sidebar_label: quorum_hasrecsig
+description: "Syscoin Core CLI reference: quorum_hasrecsig"
+---
+
+# `quorum_hasrecsig`
+
+Test if a valid recovered signature is present.
+
+## Synopsis
+
+```
+quorum_hasrecsig "id" "msgHash"
+```
+
+## Arguments
+
+```
+1. id         (string, required) Request id.
+              
+2. msgHash    (string, required) Message hash.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_hasrecsig 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_hasrecsig", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_info.mdx
+++ b/docs/cli/evo/quorum_info.mdx
@@ -1,0 +1,34 @@
+---
+title: quorum_info
+sidebar_label: quorum_info
+description: "Syscoin Core CLI reference: quorum_info"
+---
+
+# `quorum_info`
+
+Return information about a quorum
+
+## Synopsis
+
+```
+quorum_info "quorumHash" ( includeSkShare )
+```
+
+## Arguments
+
+```
+1. quorumHash        (string, required) Block hash of quorum.
+                     
+2. includeSkShare    (boolean, optional, default=false) Include secret key share in output.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_info 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_info", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_isconflicting.mdx
+++ b/docs/cli/evo/quorum_isconflicting.mdx
@@ -1,0 +1,34 @@
+---
+title: quorum_isconflicting
+sidebar_label: quorum_isconflicting
+description: "Syscoin Core CLI reference: quorum_isconflicting"
+---
+
+# `quorum_isconflicting`
+
+Test if a conflict exists.
+
+## Synopsis
+
+```
+quorum_isconflicting "id" "msgHash"
+```
+
+## Arguments
+
+```
+1. id         (string, required) Request id.
+              
+2. msgHash    (string, required) Message hash.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_isconflicting 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_isconflicting", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_list.mdx
+++ b/docs/cli/evo/quorum_list.mdx
@@ -1,0 +1,33 @@
+---
+title: quorum_list
+sidebar_label: quorum_list
+description: "Syscoin Core CLI reference: quorum_list"
+---
+
+# `quorum_list`
+
+List of on-chain quorums
+
+## Synopsis
+
+```
+quorum_list ( count )
+```
+
+## Arguments
+
+```
+1. count    (numeric, optional, default=0) Number of quorums to list. Will list active quorums
+            if "count" is not specified.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_list 1
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_list", "params": [1]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_memberof.mdx
+++ b/docs/cli/evo/quorum_memberof.mdx
@@ -1,0 +1,35 @@
+---
+title: quorum_memberof
+sidebar_label: quorum_memberof
+description: "Syscoin Core CLI reference: quorum_memberof"
+---
+
+# `quorum_memberof`
+
+Checks which quorums the given masternode is a member of.
+
+## Synopsis
+
+```
+quorum_memberof "proTxHash" ( scanQuorumsCount )
+```
+
+## Arguments
+
+```
+1. proTxHash           (string, required) ProTxHash of the masternode.
+                       
+2. scanQuorumsCount    (numeric, optional, default=-1) Number of quorums to scan for. If not specified,
+                       the active quorum count for each specific quorum type is used.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_memberof 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_memberof", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_selectquorum.mdx
+++ b/docs/cli/evo/quorum_selectquorum.mdx
@@ -1,0 +1,32 @@
+---
+title: quorum_selectquorum
+sidebar_label: quorum_selectquorum
+description: "Syscoin Core CLI reference: quorum_selectquorum"
+---
+
+# `quorum_selectquorum`
+
+Returns the quorum that would/should sign a request.
+
+## Synopsis
+
+```
+quorum_selectquorum "id"
+```
+
+## Arguments
+
+```
+1. id    (string, required) Request id.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_selectquorum 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_selectquorum", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_sign.mdx
+++ b/docs/cli/evo/quorum_sign.mdx
@@ -1,0 +1,38 @@
+---
+title: quorum_sign
+sidebar_label: quorum_sign
+description: "Syscoin Core CLI reference: quorum_sign"
+---
+
+# `quorum_sign`
+
+Threshold-sign a message.
+
+## Synopsis
+
+```
+quorum_sign "id" "msgHash" ( "quorumHash" submit )
+```
+
+## Arguments
+
+```
+1. id            (string, required) Request id.
+                 
+2. msgHash       (string, required) Message hash.
+                 
+3. quorumHash    (string, optional) The quorum identifier.
+                 
+4. submit        (boolean, optional) Submits the signature share to the network if this is true.
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_sign 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_sign", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/quorum_verify.mdx
+++ b/docs/cli/evo/quorum_verify.mdx
@@ -1,0 +1,40 @@
+---
+title: quorum_verify
+sidebar_label: quorum_verify
+description: "Syscoin Core CLI reference: quorum_verify"
+---
+
+# `quorum_verify`
+
+Test if a quorum signature is valid for a request id and a message hash.
+
+## Synopsis
+
+```
+quorum_verify "id" "msgHash" "signature" ( "quorumHash" signHeight )
+```
+
+## Arguments
+
+```
+1. id            (string, required) Request id.
+                 
+2. msgHash       (string, required) Message hash.
+                 
+3. signature     (string, required) Quorum signature to verify.
+                 
+4. quorumHash    (string, optional) The quorum identifier. Set to "" if you want to specify signHeight instead.
+                 
+5. signHeight    (numeric, optional) The height at which the message was signed. Only works when quorumHash is "".
+```
+
+## Examples
+
+```
+> syscoin-cli quorum_verify 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "quorum_verify", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/submitchainlock.mdx
+++ b/docs/cli/evo/submitchainlock.mdx
@@ -1,0 +1,33 @@
+---
+title: submitchainlock
+sidebar_label: submitchainlock
+description: "Syscoin Core CLI reference: submitchainlock"
+---
+
+# `submitchainlock`
+
+Submit a ChainLock signature if needed
+
+## Synopsis
+
+```
+submitchainlock "blockHash" "signature" "signers"
+```
+
+## Arguments
+
+```
+1. blockHash    (string, required) The block hash of the ChainLock.
+2. signature    (string, required) The signature of the ChainLock.
+3. signers      (string, required) The quorum signers of the ChainLock.
+```
+
+## Result
+
+```
+n    (numeric) The height of the current best ChainLock
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evo/verifychainlock.mdx
+++ b/docs/cli/evo/verifychainlock.mdx
@@ -1,0 +1,34 @@
+---
+title: verifychainlock
+sidebar_label: verifychainlock
+description: "Syscoin Core CLI reference: verifychainlock"
+---
+
+# `verifychainlock`
+
+Test if a quorum signature is valid for a ChainLock.
+
+## Synopsis
+
+```
+verifychainlock "blockHash" "signature" "signers"
+```
+
+## Arguments
+
+```
+1. blockHash    (string, required) The block hash of the ChainLock.
+2. signature    (string, required) The signature of the ChainLock.
+3. signers      (string, required) The quorum signers of the ChainLock.
+```
+
+## Examples
+
+```
+> syscoin-cli verifychainlock 0x0 0x0 0x0
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "verifychainlock", "params": ["0x0", "0x0", "0x0"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rpcquorums.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rpcquorums.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*


### PR DESCRIPTION
Adds 19 Evo-category RPC reference pages under `docs/cli/evo/`,
auto-generated from `syscoin-cli help` against Syscoin Core 5.0.5.

Fourth slice of the CLI reference rollout. The Evo category covers
Sentry node operations (read-only), BLS keys, ChainLocks, and the LLMQ
quorum subsystem. All Syscoin-distinctive (inherited from Dash, no
upstream Bitcoin Core equivalent).