### PR TITLE
docs: add auto-generated evowallet RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/evowallet/_category_.json
+++ b/docs/cli/evowallet/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Evo Wallet",
+  "position": 14
+}

--- a/docs/cli/evowallet/protx_info_wallet.mdx
+++ b/docs/cli/evowallet/protx_info_wallet.mdx
@@ -1,0 +1,32 @@
+---
+title: protx_info_wallet
+sidebar_label: protx_info_wallet
+description: "Syscoin Core CLI reference: protx_info_wallet"
+---
+
+# `protx_info_wallet`
+
+Returns detailed information about a deterministic masternode in current wallet.
+
+## Synopsis
+
+```
+protx_info_wallet "proTxHash"
+```
+
+## Arguments
+
+```
+1. proTxHash    (string, required) The hash of the initial ProRegTx.
+```
+
+## Examples
+
+```
+> syscoin-cli protx_info_wallet 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_info_wallet", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evowallet/protx_list_wallet.mdx
+++ b/docs/cli/evowallet/protx_list_wallet.mdx
@@ -1,0 +1,34 @@
+---
+title: protx_list_wallet
+sidebar_label: protx_list_wallet
+description: "Syscoin Core CLI reference: protx_list_wallet"
+---
+
+# `protx_list_wallet`
+
+List only ProTx which are found in your wallet at the given chain height.
+This will also include ProTx which failed PoSe verification.
+
+## Synopsis
+
+```
+protx_list_wallet ( detailed height )
+```
+
+## Arguments
+
+```
+1. detailed    (numeric, optional, default=0) If 0, only the hashes of the ProTx will be returned. If 1 returns voting details for each DMN and keys and if 2 returns full details of each DMN
+2. height      (numeric, optional) Height to look for ProTx transactions, if not specified defaults to current chain-tip
+```
+
+## Examples
+
+```
+> syscoin-cli protx_list_wallet true
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_list_wallet", "params": [true]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evowallet/protx_register.mdx
+++ b/docs/cli/evowallet/protx_register.mdx
@@ -1,0 +1,60 @@
+---
+title: protx_register
+sidebar_label: protx_register
+description: "Syscoin Core CLI reference: protx_register"
+---
+
+# `protx_register`
+
+Same as "protx_register_fund", but with an externally referenced collateral.
+The collateral is specified through "collateralHash" and "collateralIndex" and must be an unspent
+transaction output spendable by this wallet. It must also not be used by any other masternode.
+
+## Synopsis
+
+```
+protx_register "collateralHash" collateralIndex "ipAndPort" "ownerAddress" "operatorPubKey" "votingAddress" operatorReward "payoutAddress" ( "fundAddress" submit legacy )
+```
+
+## Arguments
+
+```
+1. collateralHash     (string, required) The collateral transaction hash.
+2. collateralIndex    (numeric, required) The collateral transaction output index.
+3. ipAndPort          (string, required) IP and port in the form "IP:PORT".
+                      Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards.
+4. ownerAddress       (string, required) The Syscoin address to use for payee updates and proposal voting.
+                      The corresponding private key does not have to be known by your wallet.
+                      The address must be unused and must differ from the collateralAddress.
+5. operatorPubKey     (string, required) The operator BLS public key. The BLS private key does not have to be known.
+                      It has to match the BLS private key which is later used when operating the masternode.
+6. votingAddress      (string, required) The voting key address. The private key does not have to be known by your wallet.
+                      It has to match the private key which is later used when voting on proposals.
+                      If set to an empty string, ownerAddress will be used.
+                      
+7. operatorReward     (numeric, required) The fraction in %% to share with the operator. The value must be
+                      between 0.00 and 100.00.
+8. payoutAddress      (string, required) The Syscoin address to use for masternode reward payments.
+9. fundAddress        (string, optional, default="") If specified wallet will only use coins from this address to fund ProTx.
+                      If not specified, payoutAddress is the one that is going to be used.
+                      The private key belonging to this address must be known in your wallet.
+10. submit            (boolean, optional) If true, the resulting transaction is sent to the network.
+11. legacy            (boolean, optional) Use Legacy BLS scheme (false by default
+```
+
+## Result
+
+```
+"hex"    (string) The transaction hash in hex
+```
+
+## Examples
+
+```
+> syscoin-cli protx_register 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 0 173.249.49.9:18369 tsys1q2j57a4rtserh9022a63pvk3jqmg7un55stux0v 003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r 5 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_register", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", 0, "173.249.49.9:18369", "tsys1q2j57a4rtserh9022a63pvk3jqmg7un55stux0v", "003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63", "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r", 5, "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evowallet/protx_register_fund.mdx
+++ b/docs/cli/evowallet/protx_register_fund.mdx
@@ -1,0 +1,59 @@
+---
+title: protx_register_fund
+sidebar_label: protx_register_fund
+description: "Syscoin Core CLI reference: protx_register_fund"
+---
+
+# `protx_register_fund`
+
+Creates, funds and sends a ProTx to the network. The resulting transaction will move 100000 Syscoin
+to the address specified by collateralAddress and will then function as the collateral of your
+masternode.
+
+## Synopsis
+
+```
+protx_register_fund "collateralAddress" "ipAndPort" "ownerAddress" "operatorPubKey" "votingAddress" operatorReward "payoutAddress" ( "fundAddress" submit legacy )
+```
+
+## Arguments
+
+```
+1. collateralAddress    (string, required) The Syscoin address to send the collateral to.
+2. ipAndPort            (string, required) IP and port in the form "IP:PORT".
+                        Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards.
+3. ownerAddress         (string, required) The Syscoin address to use for payee updates and proposal voting.
+                        The corresponding private key does not have to be known by your wallet.
+                        The address must be unused and must differ from the collateralAddress.
+4. operatorPubKey       (string, required) The operator BLS public key. The BLS private key does not have to be known.
+                        It has to match the BLS private key which is later used when operating the masternode.
+5. votingAddress        (string, required) The voting key address. The private key does not have to be known by your wallet.
+                        It has to match the private key which is later used when voting on proposals.
+                        If set to an empty string, ownerAddress will be used.
+                        
+6. operatorReward       (numeric, required) The fraction in %% to share with the operator. The value must be
+                        between 0.00 and 100.00.
+7. payoutAddress        (string, required) The Syscoin address to use for masternode reward payments.
+8. fundAddress          (string, optional, default="") If specified wallet will only use coins from this address to fund ProTx.
+                        If not specified, payoutAddress is the one that is going to be used.
+                        The private key belonging to this address must be known in your wallet.
+9. submit               (boolean, optional) If true, the resulting transaction is sent to the network.
+10. legacy              (boolean, optional) Use Legacy BLS scheme (false by default
+```
+
+## Result
+
+```
+"hex"    (string) The transaction hash in hex
+```
+
+## Examples
+
+```
+> syscoin-cli protx_register_fund "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r" 173.249.49.9:18369 tsys1q2j57a4rtserh9022a63pvk3jqmg7un55stux0v 003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r 5 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_register_fund", "params": ["tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r", "173.249.49.9:18369", "tsys1q2j57a4rtserh9022a63pvk3jqmg7un55stux0v", "003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63", "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r", 5, "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evowallet/protx_register_prepare.mdx
+++ b/docs/cli/evowallet/protx_register_prepare.mdx
@@ -1,0 +1,53 @@
+---
+title: protx_register_prepare
+sidebar_label: protx_register_prepare
+description: "Syscoin Core CLI reference: protx_register_prepare"
+---
+
+# `protx_register_prepare`
+
+Creates an unsigned ProTx and returns it. The ProTx must be signed externally with the collateral
+key and then passed to "protx_register_submit". The prepared transaction will also contain inputs
+and outputs to cover fees.
+
+## Synopsis
+
+```
+protx_register_prepare "collateralHash" collateralIndex "ipAndPort" "ownerAddress" "operatorPubKey" "votingAddress" operatorReward "payoutAddress" ( "fundAddress" legacy )
+```
+
+## Arguments
+
+```
+1. collateralHash     (string, required) The collateral transaction hash.
+2. collateralIndex    (numeric, required) The collateral transaction output index.
+3. ipAndPort          (string, required) IP and port in the form "IP:PORT".
+                      Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards.
+4. ownerAddress       (string, required) The Syscoin address to use for payee updates and proposal voting.
+                      The corresponding private key does not have to be known by your wallet.
+                      The address must be unused and must differ from the collateralAddress.
+5. operatorPubKey     (string, required) The operator BLS public key. The BLS private key does not have to be known.
+                      It has to match the BLS private key which is later used when operating the masternode.
+6. votingAddress      (string, required) The voting key address. The private key does not have to be known by your wallet.
+                      It has to match the private key which is later used when voting on proposals.
+                      If set to an empty string, ownerAddress will be used.
+                      
+7. operatorReward     (numeric, required) The fraction in %% to share with the operator. The value must be
+                      between 0.00 and 100.00.
+8. payoutAddress      (string, required) The Syscoin address to use for masternode reward payments.
+9. fundAddress        (string, optional, default="") If specified wallet will only use coins from this address to fund ProTx.
+                      If not specified, payoutAddress is the one that is going to be used.
+                      The private key belonging to this address must be known in your wallet.
+10. legacy            (boolean, optional) Use Legacy BLS scheme (false by default
+```
+
+## Examples
+
+```
+> syscoin-cli protx_register_prepare 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 0 173.249.49.9:18369 tsys1q2j57a4rtserh9022a63pvk3jqmg7un55stux0v 003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r 5 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_register_prepare", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", 0, "173.249.49.9:18369", "tsys1q2j57a4rtserh9022a63pvk3jqmg7un55stux0v", "003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63", "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r", 5, "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evowallet/protx_register_submit.mdx
+++ b/docs/cli/evowallet/protx_register_submit.mdx
@@ -1,0 +1,41 @@
+---
+title: protx_register_submit
+sidebar_label: protx_register_submit
+description: "Syscoin Core CLI reference: protx_register_submit"
+---
+
+# `protx_register_submit`
+
+Submits the specified ProTx to the network. This command will also sign the inputs of the transaction
+which were previously added by "protx_register_prepare" to cover transaction fees
+and outputs to cover fees.
+
+## Synopsis
+
+```
+protx_register_submit "tx" "sig"
+```
+
+## Arguments
+
+```
+1. tx     (string, required) The serialized transaction previously returned by "protx_register_prepare".
+2. sig    (string, required) The signature signed with the collateral key. Must be in base64 format.
+```
+
+## Result
+
+```
+"hex"    (string) The transaction hash in hex
+```
+
+## Examples
+
+```
+> syscoin-cli protx_register_submit 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_register_submit", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evowallet/protx_revoke.mdx
+++ b/docs/cli/evowallet/protx_revoke.mdx
@@ -1,0 +1,48 @@
+---
+title: protx_revoke
+sidebar_label: protx_revoke
+description: "Syscoin Core CLI reference: protx_revoke"
+---
+
+# `protx_revoke`
+
+Creates and sends a ProUpRevTx to the network. This will revoke the operator key of the masternode and
+put it into the PoSe-banned state. It will also set the service field of the masternode
+to zero. Use this in case your operator key got compromised or you want to stop providing your service
+to the masternode owner.
+
+## Synopsis
+
+```
+protx_revoke "proTxHash" "operatorKey" ( reason "feeSourceAddress" legacy )
+```
+
+## Arguments
+
+```
+1. proTxHash           (string, required) The hash of the initial ProRegTx.
+2. operatorKey         (string, required) The operator BLS private key associated with the
+                       registered operator public key.
+3. reason              (numeric, optional, default=0) The reason for masternode service revocation.
+4. feeSourceAddress    (string, optional) If specified wallet will only use coins from this address to fund ProTx.
+                       If not specified, payoutAddress is the one that is going to be used.
+                       The private key belonging to this address must be known in your wallet.
+5. legacy              (boolean, optional) Use Legacy BLS scheme (false by default
+```
+
+## Result
+
+```
+"hex"    (string) The transaction hash in hex
+```
+
+## Examples
+
+```
+> syscoin-cli protx_revoke 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63 0 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_revoke", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63", 0, "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evowallet/protx_update_registrar.mdx
+++ b/docs/cli/evowallet/protx_update_registrar.mdx
@@ -1,0 +1,52 @@
+---
+title: protx_update_registrar
+sidebar_label: protx_update_registrar
+description: "Syscoin Core CLI reference: protx_update_registrar"
+---
+
+# `protx_update_registrar`
+
+Creates and sends a ProUpRegTx to the network. This will update the operator key, voting key, payout
+address of the masternode specified by "proTxHash".
+The owner key of the masternode must be known to your wallet.
+
+## Synopsis
+
+```
+protx_update_registrar "proTxHash" "operatorPubKey" "votingAddress" "payoutAddress" ( "feeSourceAddress" legacy )
+```
+
+## Arguments
+
+```
+1. proTxHash           (string, required) The hash of the initial ProRegTx.
+2. operatorPubKey      (string, required) The operator BLS public key. The BLS private key does not have to be known.
+                       It has to match the BLS private key which is later used when operating the masternode.
+                       If set to an empty string, the currently active operator BLS public key is reused.
+3. votingAddress       (string, required) The voting key address. The private key does not have to be known by your wallet.
+                       It has to match the private key which is later used when voting on proposals.
+                       If set to an empty string, the currently active voting key address is reused.
+4. payoutAddress       (string, required) The Syscoin address to use for masternode reward payments.
+                       If set to an empty string, the currently active payout address is reused.
+5. feeSourceAddress    (string, optional, default="") If specified wallet will only use coins from this address to fund ProTx.
+                       If not specified, payoutAddress is the one that is going to be used.
+                       The private key belonging to this address must be known in your wallet.
+6. legacy              (boolean, optional) Use Legacy BLS scheme (false by default
+```
+
+## Result
+
+```
+"hex"    (string) The transaction hash in hex
+```
+
+## Examples
+
+```
+> syscoin-cli protx_update_registrar 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_update_registrar", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63", "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r", "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*

--- a/docs/cli/evowallet/protx_update_service.mdx
+++ b/docs/cli/evowallet/protx_update_service.mdx
@@ -1,0 +1,53 @@
+---
+title: protx_update_service
+sidebar_label: protx_update_service
+description: "Syscoin Core CLI reference: protx_update_service"
+---
+
+# `protx_update_service`
+
+Creates and sends a ProUpServTx to the network. This will update the IP address
+of a masternode.
+If this is done for a masternode that got PoSe-banned, the ProUpServTx will also revive this masternode.
+
+## Synopsis
+
+```
+protx_update_service "proTxHash" "ipAndPort" "operatorKey" "nevmAddress" ( "operatorPayoutAddress" "feeSourceAddress" legacy )
+```
+
+## Arguments
+
+```
+1. proTxHash                (string, required) The hash of the initial ProRegTx.
+2. ipAndPort                (string, required) IP and port in the form "IP:PORT".
+                            Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards.
+3. operatorKey              (string, required) The operator BLS private key associated with the
+                            registered operator public key.
+4. nevmAddress              (string, required) The NEVM address to associate with NEVM registry.
+                            If set to an empty string, any existing NEVM registry entry will be removed.
+5. operatorPayoutAddress    (string, optional, default="") The address used for operator reward payments.
+                            Only allowed when the ProRegTx had a non-zero operatorReward value.
+                            If set to an empty string, the currently active payout address is reused.
+6. feeSourceAddress         (string, optional, default="") If specified, the wallet will only use coins from this address to fund ProTx.
+                            If not specified, payoutAddress is the one that is going to be used.
+                            The private key belonging to this address must be known in your wallet.
+7. legacy                   (boolean, optional) Use Legacy BLS scheme (false by default)
+```
+
+## Result
+
+```
+"hex"    (string) The transaction hash in hex
+```
+
+## Examples
+
+```
+> syscoin-cli protx_update_service 1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d 173.249.49.9:18369 <NEVM address> 003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63 tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "protx_update_service", "params": ["1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "173.249.49.9:18369", "<NEVM Address>", "003bc97fcd6023996f8703b4da34dedd1641bd45ed12ac7a4d74a529dd533ecb99d4fb8ddb04853bb110f0d747ee8e63", "tsys1qxh8am0c9w0q9kv7h7f9q2c4jrfjg63yawrgm0r")]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcevo.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcevo.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-19.*


### PR DESCRIPTION
Adds 9 Evowallet-category RPC reference pages under
`docs/cli/evowallet/`, auto-generated from `syscoin-cli help` against
Syscoin Core 5.0.5.

Fifth slice of the CLI reference rollout. The Evowallet category covers
the wallet-side ProTx operations that build, sign, and submit
Sentry-node-related transactions. Together with the Evo category
(read-only chainlock/quorum/protx queries), this completes the Sentry
node operator RPC surface.