### PR TITLE
docs: add auto-generated rawtransactions RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/rawtransactions/_category_.json
+++ b/docs/cli/rawtransactions/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Raw Transactions",
+  "position": 3
+}

--- a/docs/cli/rawtransactions/analyzepsbt.mdx
+++ b/docs/cli/rawtransactions/analyzepsbt.mdx
@@ -1,0 +1,63 @@
+---
+title: analyzepsbt
+sidebar_label: analyzepsbt
+description: "Syscoin Core CLI reference: analyzepsbt"
+---
+
+# `analyzepsbt`
+
+Analyzes and provides information about the current status of a PSBT and its inputs
+
+## Synopsis
+
+```
+analyzepsbt "psbt"
+```
+
+## Arguments
+
+```
+1. psbt    (string, required) A base64 string of a PSBT
+```
+
+## Result
+
+```
+{                                   (json object)
+  "inputs" : [                      (json array, optional)
+    {                               (json object)
+      "has_utxo" : true|false,      (boolean) Whether a UTXO is provided
+      "is_final" : true|false,      (boolean) Whether the input is finalized
+      "missing" : {                 (json object, optional) Things that are missing that are required to complete this input
+        "pubkeys" : [               (json array, optional)
+          "hex",                    (string) Public key ID, hash160 of the public key, of a public key whose BIP 32 derivation path is missing
+          ...
+        ],
+        "signatures" : [            (json array, optional)
+          "hex",                    (string) Public key ID, hash160 of the public key, of a public key whose signature is missing
+          ...
+        ],
+        "redeemscript" : "hex",     (string, optional) Hash160 of the redeemScript that is missing
+        "witnessscript" : "hex"     (string, optional) SHA256 of the witnessScript that is missing
+      },
+      "next" : "str"                (string, optional) Role of the next person that this input needs to go to
+    },
+    ...
+  ],
+  "estimated_vsize" : n,            (numeric, optional) Estimated vsize of the final signed transaction
+  "estimated_feerate" : n,          (numeric, optional) Estimated feerate of the final signed transaction in SYS/kvB. Shown only if all UTXO slots in the PSBT have been filled
+  "fee" : n,                        (numeric, optional) The transaction fee paid. Shown only if all UTXO slots in the PSBT have been filled
+  "next" : "str",                   (string) Role of the next person that this psbt needs to go to
+  "error" : "str"                   (string, optional) Error message (if there is one)
+}
+```
+
+## Examples
+
+```
+> syscoin-cli analyzepsbt "psbt"
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/combinepsbt.mdx
+++ b/docs/cli/rawtransactions/combinepsbt.mdx
@@ -1,0 +1,42 @@
+---
+title: combinepsbt
+sidebar_label: combinepsbt
+description: "Syscoin Core CLI reference: combinepsbt"
+---
+
+# `combinepsbt`
+
+Combine multiple partially signed Syscoin transactions into one transaction.
+Implements the Combiner role.
+
+## Synopsis
+
+```
+combinepsbt ["psbt",...]
+```
+
+## Arguments
+
+```
+1. txs            (json array, required) The base64 strings of partially signed transactions
+     [
+       "psbt",    (string) A base64 string of a PSBT
+       ...
+     ]
+```
+
+## Result
+
+```
+"str"    (string) The base64-encoded partially signed transaction
+```
+
+## Examples
+
+```
+> syscoin-cli combinepsbt '["mybase64_1", "mybase64_2", "mybase64_3"]'
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/combinerawtransaction.mdx
+++ b/docs/cli/rawtransactions/combinerawtransaction.mdx
@@ -1,0 +1,43 @@
+---
+title: combinerawtransaction
+sidebar_label: combinerawtransaction
+description: "Syscoin Core CLI reference: combinerawtransaction"
+---
+
+# `combinerawtransaction`
+
+Combine multiple partially signed transactions into one transaction.
+The combined transaction may be another partially signed transaction or a 
+fully signed transaction.
+
+## Synopsis
+
+```
+combinerawtransaction ["hexstring",...]
+```
+
+## Arguments
+
+```
+1. txs                 (json array, required) The hex strings of partially signed transactions
+     [
+       "hexstring",    (string) A hex-encoded raw transaction
+       ...
+     ]
+```
+
+## Result
+
+```
+"str"    (string) The hex-encoded raw transaction with signature(s)
+```
+
+## Examples
+
+```
+> syscoin-cli combinerawtransaction '["myhex1", "myhex2", "myhex3"]'
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/converttopsbt.mdx
+++ b/docs/cli/rawtransactions/converttopsbt.mdx
@@ -1,0 +1,50 @@
+---
+title: converttopsbt
+sidebar_label: converttopsbt
+description: "Syscoin Core CLI reference: converttopsbt"
+---
+
+# `converttopsbt`
+
+Converts a network serialized transaction to a PSBT. This should be used only with createrawtransaction and fundrawtransaction
+createpsbt and walletcreatefundedpsbt should be used for new applications.
+
+## Synopsis
+
+```
+converttopsbt "hexstring" ( permitsigdata iswitness )
+```
+
+## Arguments
+
+```
+1. hexstring        (string, required) The hex string of a raw transaction
+2. permitsigdata    (boolean, optional, default=false) If true, any signatures in the input will be discarded and conversion
+                    will continue. If false, RPC will fail if any signatures are present.
+3. iswitness        (boolean, optional, default=depends on heuristic tests) Whether the transaction hex is a serialized witness transaction.
+                    If iswitness is not present, heuristic tests will be used in decoding.
+                    If true, only witness deserialization will be tried.
+                    If false, only non-witness deserialization will be tried.
+                    This boolean should reflect whether the transaction has inputs
+                    (e.g. fully valid, or on-chain transactions), if known by the caller.
+```
+
+## Result
+
+```
+"str"    (string) The resulting raw transaction (base64-encoded string)
+```
+
+## Examples
+
+```
+Create a transaction
+> syscoin-cli createrawtransaction "[{\"txid\":\"myid\",\"vout\":0}]" "[{\"data\":\"00010203\"}]"
+
+Convert the transaction to a PSBT
+> syscoin-cli converttopsbt "rawtransaction"
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/createpsbt.mdx
+++ b/docs/cli/rawtransactions/createpsbt.mdx
@@ -1,0 +1,66 @@
+---
+title: createpsbt
+sidebar_label: createpsbt
+description: "Syscoin Core CLI reference: createpsbt"
+---
+
+# `createpsbt`
+
+Creates a transaction in the Partially Signed Transaction format.
+Implements the Creator role.
+
+## Synopsis
+
+```
+createpsbt [{"txid":"hex","vout":n,"sequence":n},...] [{"address":amount,...},{"data":"hex","data_amount":amount,"data_version":n},...] ( locktime replaceable )
+```
+
+## Arguments
+
+```
+1. inputs                          (json array, required) The inputs
+     [
+       {                           (json object)
+         "txid": "hex",            (string, required) The transaction id
+         "vout": n,                (numeric, required) The output number
+         "sequence": n,            (numeric, optional, default=depends on the value of the 'replaceable' and 'locktime' arguments) The sequence number
+       },
+       ...
+     ]
+2. outputs                         (json array, required) The outputs specified as key-value pairs.
+                                   Each key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.
+                                   At least one output of either type must be specified.
+                                   For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also
+                                   accepted as second parameter.
+     [
+       {                           (json object)
+         "address": amount,        (numeric or string, required) A key-value pair. The key (string) is the syscoin address, the value (float or string) is the amount in SYS
+         ...
+       },
+       {                           (json object)
+         "data": "hex",            (string, required) A key-value pair. The key must be "data", the value is hex-encoded data
+         "data_amount": amount,    (numeric or string, optional, default=0) Amount to burn in OP_RETURN output for Syscoin transactions
+         "data_version": n,        (numeric, optional, default=0) Transaction version to use for Syscoin transactions
+       },
+       ...
+     ]
+3. locktime                        (numeric, optional, default=0) Raw locktime. Non-0 value also locktime-activates inputs
+4. replaceable                     (boolean, optional, default=true) Marks this transaction as BIP125-replaceable.
+                                   Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.
+```
+
+## Result
+
+```
+"str"    (string) The resulting raw transaction (base64-encoded string)
+```
+
+## Examples
+
+```
+> syscoin-cli createpsbt "[{\"txid\":\"myid\",\"vout\":0}]" "[{\"data\":\"00010203\"}]"
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/createrawtransaction.mdx
+++ b/docs/cli/rawtransactions/createrawtransaction.mdx
@@ -1,0 +1,72 @@
+---
+title: createrawtransaction
+sidebar_label: createrawtransaction
+description: "Syscoin Core CLI reference: createrawtransaction"
+---
+
+# `createrawtransaction`
+
+Create a transaction spending the given inputs and creating new outputs.
+Outputs can be addresses or data.
+Returns hex-encoded raw transaction.
+Note that the transaction's inputs are not signed, and
+it is not stored in the wallet or transmitted to the network.
+
+## Synopsis
+
+```
+createrawtransaction [{"txid":"hex","vout":n,"sequence":n},...] [{"address":amount,...},{"data":"hex","data_amount":amount,"data_version":n},...] ( locktime replaceable )
+```
+
+## Arguments
+
+```
+1. inputs                          (json array, required) The inputs
+     [
+       {                           (json object)
+         "txid": "hex",            (string, required) The transaction id
+         "vout": n,                (numeric, required) The output number
+         "sequence": n,            (numeric, optional, default=depends on the value of the 'replaceable' and 'locktime' arguments) The sequence number
+       },
+       ...
+     ]
+2. outputs                         (json array, required) The outputs specified as key-value pairs.
+                                   Each key may only appear once, i.e. there can only be one 'data' output, and no address may be duplicated.
+                                   At least one output of either type must be specified.
+                                   For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also
+                                   accepted as second parameter.
+     [
+       {                           (json object)
+         "address": amount,        (numeric or string, required) A key-value pair. The key (string) is the syscoin address, the value (float or string) is the amount in SYS
+         ...
+       },
+       {                           (json object)
+         "data": "hex",            (string, required) A key-value pair. The key must be "data", the value is hex-encoded data
+         "data_amount": amount,    (numeric or string, optional, default=0) Amount to burn in OP_RETURN output for Syscoin transactions
+         "data_version": n,        (numeric, optional, default=0) Transaction version to use for Syscoin transactions
+       },
+       ...
+     ]
+3. locktime                        (numeric, optional, default=0) Raw locktime. Non-0 value also locktime-activates inputs
+4. replaceable                     (boolean, optional, default=true) Marks this transaction as BIP125-replaceable.
+                                   Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.
+```
+
+## Result
+
+```
+"hex"    (string) hex string of the transaction
+```
+
+## Examples
+
+```
+> syscoin-cli createrawtransaction "[{\"txid\":\"myid\",\"vout\":0}]" "[{\"address\":0.01}]"
+> syscoin-cli createrawtransaction "[{\"txid\":\"myid\",\"vout\":0}]" "[{\"data\":\"00010203\"}]"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "createrawtransaction", "params": ["[{\"txid\":\"myid\",\"vout\":0}]", "[{\"address\":0.01}]"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "createrawtransaction", "params": ["[{\"txid\":\"myid\",\"vout\":0}]", "[{\"data\":\"00010203\"}]"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/decodepsbt.mdx
+++ b/docs/cli/rawtransactions/decodepsbt.mdx
@@ -1,0 +1,233 @@
+---
+title: decodepsbt
+sidebar_label: decodepsbt
+description: "Syscoin Core CLI reference: decodepsbt"
+---
+
+# `decodepsbt`
+
+Return a JSON object representing the serialized, base64-encoded partially signed Syscoin transaction.
+
+## Synopsis
+
+```
+decodepsbt "psbt"
+```
+
+## Arguments
+
+```
+1. psbt    (string, required) The PSBT base64 string
+```
+
+## Result
+
+```
+{                                          (json object)
+  "tx" : {                                 (json object) The decoded network-serialized unsigned transaction.
+    ...                                    The layout is the same as the output of decoderawtransaction.
+  },
+  "global_xpubs" : [                       (json array)
+    {                                      (json object)
+      "xpub" : "str",                      (string) The extended public key this path corresponds to
+      "master_fingerprint" : "hex",        (string) The fingerprint of the master key
+      "path" : "str"                       (string) The path
+    },
+    ...
+  ],
+  "psbt_version" : n,                      (numeric) The PSBT version number. Not to be confused with the unsigned transaction version
+  "proprietary" : [                        (json array) The global proprietary map
+    {                                      (json object)
+      "identifier" : "hex",                (string) The hex string for the proprietary identifier
+      "subtype" : n,                       (numeric) The number for the subtype
+      "key" : "hex",                       (string) The hex for the key
+      "value" : "hex"                      (string) The hex for the value
+    },
+    ...
+  ],
+  "unknown" : {                            (json object) The unknown global fields
+    "key" : "hex",                         (string) (key-value pair) An unknown key-value pair
+    ...
+  },
+  "inputs" : [                             (json array)
+    {                                      (json object)
+      "non_witness_utxo" : {               (json object, optional) Decoded network transaction for non-witness UTXOs
+        ...
+      },
+      "witness_utxo" : {                   (json object, optional) Transaction output for witness UTXOs
+        "amount" : n,                      (numeric) The value in SYS
+        "scriptPubKey" : {                 (json object)
+          "asm" : "str",                   (string) Disassembly of the public key script
+          "desc" : "str",                  (string) Inferred descriptor for the output
+          "hex" : "hex",                   (string) The raw public key script bytes, hex-encoded
+          "type" : "str",                  (string) The type, eg 'pubkeyhash'
+          "address" : "str"                (string, optional) The Syscoin address (only if a well-defined address exists)
+        }
+      },
+      "partial_signatures" : {             (json object, optional)
+        "pubkey" : "str",                  (string) The public key and signature that corresponds to it.
+        ...
+      },
+      "sighash" : "str",                   (string, optional) The sighash type to be used
+      "redeem_script" : {                  (json object, optional)
+        "asm" : "str",                     (string) Disassembly of the redeem script
+        "hex" : "hex",                     (string) The raw redeem script bytes, hex-encoded
+        "type" : "str"                     (string) The type, eg 'pubkeyhash'
+      },
+      "witness_script" : {                 (json object, optional)
+        "asm" : "str",                     (string) Disassembly of the witness script
+        "hex" : "hex",                     (string) The raw witness script bytes, hex-encoded
+        "type" : "str"                     (string) The type, eg 'pubkeyhash'
+      },
+      "bip32_derivs" : [                   (json array, optional)
+        {                                  (json object)
+          "pubkey" : "str",                (string) The public key with the derivation path as the value.
+          "master_fingerprint" : "str",    (string) The fingerprint of the master key
+          "path" : "str"                   (string) The path
+        },
+        ...
+      ],
+      "final_scriptSig" : {                (json object, optional)
+        "asm" : "str",                     (string) Disassembly of the final signature script
+        "hex" : "hex"                      (string) The raw final signature script bytes, hex-encoded
+      },
+      "final_scriptwitness" : [            (json array, optional)
+        "hex",                             (string) hex-encoded witness data (if any)
+        ...
+      ],
+      "ripemd160_preimages" : {            (json object, optional)
+        "hash" : "str",                    (string) The hash and preimage that corresponds to it.
+        ...
+      },
+      "sha256_preimages" : {               (json object, optional)
+        "hash" : "str",                    (string) The hash and preimage that corresponds to it.
+        ...
+      },
+      "hash160_preimages" : {              (json object, optional)
+        "hash" : "str",                    (string) The hash and preimage that corresponds to it.
+        ...
+      },
+      "hash256_preimages" : {              (json object, optional)
+        "hash" : "str",                    (string) The hash and preimage that corresponds to it.
+        ...
+      },
+      "taproot_key_path_sig" : "hex",      (string, optional) hex-encoded signature for the Taproot key path spend
+      "taproot_script_path_sigs" : [       (json array, optional)
+        {                                  (json object, optional) The signature for the pubkey and leaf hash combination
+          "pubkey" : "str",                (string) The x-only pubkey for this signature
+          "leaf_hash" : "str",             (string) The leaf hash for this signature
+          "sig" : "str"                    (string) The signature itself
+        },
+        ...
+      ],
+      "taproot_scripts" : [                (json array, optional)
+        {                                  (json object)
+          "script" : "hex",                (string) A leaf script
+          "leaf_ver" : n,                  (numeric) The version number for the leaf script
+          "control_blocks" : [             (json array) The control blocks for this script
+            "hex",                         (string) A hex-encoded control block for this script
+            ...
+          ]
+        },
+        ...
+      ],
+      "taproot_bip32_derivs" : [           (json array, optional)
+        {                                  (json object)
+          "pubkey" : "str",                (string) The x-only public key this path corresponds to
+          "master_fingerprint" : "str",    (string) The fingerprint of the master key
+          "path" : "str",                  (string) The path
+          "leaf_hashes" : [                (json array) The hashes of the leaves this pubkey appears in
+            "hex",                         (string) The hash of a leaf this pubkey appears in
+            ...
+          ]
+        },
+        ...
+      ],
+      "taproot_internal_key" : "hex",      (string, optional) The hex-encoded Taproot x-only internal key
+      "taproot_merkle_root" : "hex",       (string, optional) The hex-encoded Taproot merkle root
+      "unknown" : {                        (json object, optional) The unknown input fields
+        "key" : "hex",                     (string) (key-value pair) An unknown key-value pair
+        ...
+      },
+      "proprietary" : [                    (json array, optional) The input proprietary map
+        {                                  (json object)
+          "identifier" : "hex",            (string) The hex string for the proprietary identifier
+          "subtype" : n,                   (numeric) The number for the subtype
+          "key" : "hex",                   (string) The hex for the key
+          "value" : "hex"                  (string) The hex for the value
+        },
+        ...
+      ]
+    },
+    ...
+  ],
+  "outputs" : [                            (json array)
+    {                                      (json object)
+      "redeem_script" : {                  (json object, optional)
+        "asm" : "str",                     (string) Disassembly of the redeem script
+        "hex" : "hex",                     (string) The raw redeem script bytes, hex-encoded
+        "type" : "str"                     (string) The type, eg 'pubkeyhash'
+      },
+      "witness_script" : {                 (json object, optional)
+        "asm" : "str",                     (string) Disassembly of the witness script
+        "hex" : "hex",                     (string) The raw witness script bytes, hex-encoded
+        "type" : "str"                     (string) The type, eg 'pubkeyhash'
+      },
+      "bip32_derivs" : [                   (json array, optional)
+        {                                  (json object)
+          "pubkey" : "str",                (string) The public key this path corresponds to
+          "master_fingerprint" : "str",    (string) The fingerprint of the master key
+          "path" : "str"                   (string) The path
+        },
+        ...
+      ],
+      "taproot_internal_key" : "hex",      (string, optional) The hex-encoded Taproot x-only internal key
+      "taproot_tree" : [                   (json array, optional) The tuples that make up the Taproot tree, in depth first search order
+        {                                  (json object, optional) A single leaf script in the taproot tree
+          "depth" : n,                     (numeric) The depth of this element in the tree
+          "leaf_ver" : n,                  (numeric) The version of this leaf
+          "script" : "str"                 (string) The hex-encoded script itself
+        },
+        ...
+      ],
+      "taproot_bip32_derivs" : [           (json array, optional)
+        {                                  (json object)
+          "pubkey" : "str",                (string) The x-only public key this path corresponds to
+          "master_fingerprint" : "str",    (string) The fingerprint of the master key
+          "path" : "str",                  (string) The path
+          "leaf_hashes" : [                (json array) The hashes of the leaves this pubkey appears in
+            "hex",                         (string) The hash of a leaf this pubkey appears in
+            ...
+          ]
+        },
+        ...
+      ],
+      "unknown" : {                        (json object, optional) The unknown output fields
+        "key" : "hex",                     (string) (key-value pair) An unknown key-value pair
+        ...
+      },
+      "proprietary" : [                    (json array, optional) The output proprietary map
+        {                                  (json object)
+          "identifier" : "hex",            (string) The hex string for the proprietary identifier
+          "subtype" : n,                   (numeric) The number for the subtype
+          "key" : "hex",                   (string) The hex for the key
+          "value" : "hex"                  (string) The hex for the value
+        },
+        ...
+      ]
+    },
+    ...
+  ],
+  "fee" : n                                (numeric, optional) The transaction fee paid if all UTXOs slots in the PSBT have been filled.
+}
+```
+
+## Examples
+
+```
+> syscoin-cli decodepsbt "psbt"
+```
+
+---
+
+*Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/decoderawtransaction.mdx
+++ b/docs/cli/rawtransactions/decoderawtransaction.mdx
@@ -1,0 +1,157 @@
+---
+title: decoderawtransaction
+sidebar_label: decoderawtransaction
+description: "Syscoin Core CLI reference: decoderawtransaction"
+---
+
+# `decoderawtransaction`
+
+Return a JSON object representing the serialized, hex-encoded transaction.
+
+## Synopsis
+
+```
+decoderawtransaction "hexstring" ( iswitness )
+```
+
+## Arguments
+
+```
+1. hexstring    (string, required) The transaction hex string
+2. iswitness    (boolean, optional, default=depends on heuristic tests) Whether the transaction hex is a serialized witness transaction.
+                If iswitness is not present, heuristic tests will be used in decoding.
+                If true, only witness deserialization will be tried.
+                If false, only non-witness deserialization will be tried.
+                This boolean should reflect whether the transaction has inputs
+                (e.g. fully valid, or on-chain transactions), if known by the caller.
+```
+
+## Result
+
+```
+{                                       (json object)
+  "txid" : "hex",                       (string) The transaction id
+  "hash" : "hex",                       (string) The transaction hash (differs from txid for witness transactions)
+  "size" : n,                           (numeric) The serialized transaction size
+  "vsize" : n,                          (numeric) The virtual transaction size (differs from size for witness transactions)
+  "weight" : n,                         (numeric) The transaction's weight (between vsize*4-3 and vsize*4)
+  "version" : n,                        (numeric) The version
+  "locktime" : xxx,                     (numeric) The lock time
+  "vin" : [                             (json array)
+    {                                   (json object)
+      "coinbase" : "hex",               (string, optional) The coinbase value (only if coinbase transaction)
+      "txid" : "hex",                   (string, optional) The transaction id (if not coinbase transaction)
+      "vout" : n,                       (numeric, optional) The output number (if not coinbase transaction)
+      "scriptSig" : {                   (json object, optional) The script (if not coinbase transaction)
+        "asm" : "str",                  (string) Disassembly of the signature script
+        "hex" : "hex"                   (string) The raw signature script bytes, hex-encoded
+      },
+      "txinwitness" : [                 (json array, optional)
+        "hex",                          (string) hex-encoded witness data (if any)
+        ...
+      ],
+      "sequence" : n                    (numeric) The script sequence number
+    },
+    ...
+  ],
+  "vout" : [                            (json array)
+    {                                   (json object)
+      "value" : n,                      (numeric) The value in SYS
+      "n" : n,                          (numeric) index
+      "scriptPubKey" : {                (json object)
+        "asm" : "str",                  (string) Disassembly of the public key script
+        "desc" : "str",                 (string) Inferred descriptor for the output
+        "hex" : "hex",                  (string) The raw public key script bytes, hex-encoded
+        "address" : "str",              (string, optional) The Syscoin address (only if a well-defined address exists)
+        "type" : "str"                  (string) The type (one of: nonstandard, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)
+      },
+      "asset_guid" : n,                 (numeric, optional) asset
+      "asset_value" : n                 (numeric, optional) The asset value in SYS
+    },
+    ...
+  ],
+  "systx" : {                           (json object, optional)
+    "txtype" : "str",                   (string) Transaction type
+    "nevm_destination" : "str",         (string, optional) NEVM destination address
+    "spv_proof" : {                     (json object, optional)
+      "txhash" : "hex",                 (string) Transaction Hash
+      "blockhash" : "hex",              (string) Block Hash
+      "postx" : "hex",                  (string) postx
+      "txroot" : "hex",                 (string) txroot
+      "txparentnodes" : "str",          (string) txparentsnode
+      "txpath" : "str",                 (string) txpath
+      "posReceipt" : "str",             (string) pos receipt
+      "receiptroot" : "str",            (string) receipt root
+      "receiptparentnodes" : "str"      (string) Receipt parent nodes
+    }
+  },
+  "proRegTx" : {                        (json object, optional)
+    "version" : n,                      (numeric) Version
+    "collateralHash" : "hex",           (string) Collateral Hash
+    "collateralIndex" : n,              (numeric) Collateral Index
+    "service" : "str",                  (string) Service IP
+    "ownerAddress" : "str",             (string) Owner Address
+    "votingAddress" : "str",            (string) Voting Address
+    "payoutAddress" : "str",            (string, optional) Payout Address
+    "pubKeyOperator" : "hex",           (string) Operator public key
+    "operatorReward" : n,               (numeric) Operator reward
+    "inputsHash" : "hex"                (string) Inputs Hash
+  },
+  "proUpServTx" : {                     (json object, optional)
+    "version" : n,                      (numeric) Version
+    "proTxHash" : "hex",                (string) proTxHash
+    "service" : "str",                  (string) Service IP
+    "payoutAddress" : "str",            (string, optional) Payout Address
+    "inputsHash" : "hex"                (string) Inputs Hash
+  },
+  "proUpRegTx" : {                      (json object, optional)
+    "version" : n,                      (numeric) Version
+    "proTxHash" : "hex",                (string) proTxHash
+    "votingAddress" : "str",            (string) Voting Address
+    "nevmAddress" : "str",              (string) NEVM Address
+    "payoutAddress" : "str",            (string, optional) Payout Address
+    "pubKeyOperator" : "hex",           (string) Operator public key
+    "inputsHash" : "hex"                (string) Inputs Hash
+  },
+  "proUpRevTx" : {                      (json object, optional)
+    "version" : n,                      (numeric) Version
+    "proTxHash" : "hex",                (string) proTxHash
+    "reason" : n,                       (numeric) Reason code
+    "inputsHash" : "hex"                (string) Inputs Hash
+  },
+  "cbTx" : {                            (json object, optional)
+    "version" : n,                      (numeric) Version
+    "height" : n,                       (numeric) Height
+    "merkleRootMNList" : "str",         (string) Merkle Root MN List
+    "merkleRootQuorums" : "str"         (string) Merkle Root Quorums
+  },
+  "qcTx" : {                            (json object, optional)
+    "commitments" : [                   (json array, optional) Commitments
+      {                                 (json object, optional) Commitment Object
+        "version" : n,                  (numeric) Version
+        "quorumHash" : "str",           (string) Quorum Hash
+        "signersCount" : "str",         (string) Signers Count
+        "signers" : "hex",              (string) Signers
+        "validMembersCount" : "str",    (string) Valid Members Count
+        "validMembers" : "hex",         (string) Valid Members
+        "quorumPublicKey" : "str",      (string) Quorum Public Key
+        "quorumVvecHash" : "str",       (string) Quorum Vvec Hash
+        "quorumSig" : "str",            (string) Quorum Sig
+        "membersSig" : "str"            (string) Members Sig
+      },
+      ...
+    ]
+  }
+}
+```
+
+## Examples
+
+```
+> syscoin-cli decoderawtransaction "hexstring"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "decoderawtransaction", "params": ["hexstring"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/decodescript.mdx
+++ b/docs/cli/rawtransactions/decodescript.mdx
@@ -1,0 +1,52 @@
+---
+title: decodescript
+sidebar_label: decodescript
+description: "Syscoin Core CLI reference: decodescript"
+---
+
+# `decodescript`
+
+Decode a hex-encoded script.
+
+## Synopsis
+
+```
+decodescript "hexstring"
+```
+
+## Arguments
+
+```
+1. hexstring    (string, required) the hex-encoded script
+```
+
+## Result
+
+```
+{                             (json object)
+  "asm" : "str",              (string) Script public key
+  "desc" : "str",             (string) Inferred descriptor for the script
+  "type" : "str",             (string) The output type (e.g. nonstandard, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_scripthash, witness_v0_keyhash, witness_v1_taproot, witness_unknown)
+  "address" : "str",          (string, optional) The Syscoin address (only if a well-defined address exists)
+  "p2sh" : "str",             (string, optional) address of P2SH script wrapping this redeem script (not returned for types that should not be wrapped)
+  "segwit" : {                (json object, optional) Result of a witness script public key wrapping this redeem script (not returned for types that should not be wrapped)
+    "asm" : "str",            (string) String representation of the script public key
+    "hex" : "hex",            (string) Hex string of the script public key
+    "type" : "str",           (string) The type of the script public key (e.g. witness_v0_keyhash or witness_v0_scripthash)
+    "address" : "str",        (string, optional) The Syscoin address (only if a well-defined address exists)
+    "desc" : "str",           (string) Inferred descriptor for the script
+    "p2sh-segwit" : "str"     (string) address of the P2SH script wrapping this witness redeem script
+  }
+}
+```
+
+## Examples
+
+```
+> syscoin-cli decodescript "hexstring"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "decodescript", "params": ["hexstring"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/descriptorprocesspsbt.mdx
+++ b/docs/cli/rawtransactions/descriptorprocesspsbt.mdx
@@ -1,0 +1,62 @@
+---
+title: descriptorprocesspsbt
+sidebar_label: descriptorprocesspsbt
+description: "Syscoin Core CLI reference: descriptorprocesspsbt"
+---
+
+# `descriptorprocesspsbt`
+
+Update all segwit inputs in a PSBT with information from output descriptors, the UTXO set or the mempool. 
+Then, sign the inputs we are able to with information from the output descriptors.
+
+## Synopsis
+
+```
+descriptorprocesspsbt "psbt" ["",{"desc":"str","range":n or [n,n]},...] ( "sighashtype" bip32derivs finalize )
+```
+
+## Arguments
+
+```
+1. psbt                          (string, required) The transaction base64 string
+2. descriptors                   (json array, required) An array of either strings or objects
+     [
+       "",                       (string) An output descriptor
+       {                         (json object) An object with an output descriptor and extra information
+         "desc": "str",          (string, required) An output descriptor
+         "range": n or [n,n],    (numeric or array, optional, default=1000) Up to what index HD chains should be explored (either end or [begin,end])
+       },
+       ...
+     ]
+3. sighashtype                   (string, optional, default="DEFAULT for Taproot, ALL otherwise") The signature hash type to sign with if not specified by the PSBT. Must be one of
+                                 "DEFAULT"
+                                 "ALL"
+                                 "NONE"
+                                 "SINGLE"
+                                 "ALL|ANYONECANPAY"
+                                 "NONE|ANYONECANPAY"
+                                 "SINGLE|ANYONECANPAY"
+4. bip32derivs                   (boolean, optional, default=true) Include BIP 32 derivation paths for public keys if we know them
+5. finalize                      (boolean, optional, default=true) Also finalize inputs if possible
+```
+
+## Result
+
+```
+{                             (json object)
+  "psbt" : "str",             (string) The base64-encoded partially signed transaction
+  "complete" : true|false,    (boolean) If the transaction has a complete set of signatures
+  "hex" : "hex"               (string, optional) The hex-encoded network transaction if complete
+}
+```
+
+## Examples
+
+```
+> syscoin-cli descriptorprocesspsbt "psbt" "[\"descriptor1\", \"descriptor2\"]"
+> syscoin-cli descriptorprocesspsbt "psbt" "[{\"desc\":\"mydescriptor\", \"range\":21}]"
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/finalizepsbt.mdx
+++ b/docs/cli/rawtransactions/finalizepsbt.mdx
@@ -1,0 +1,46 @@
+---
+title: finalizepsbt
+sidebar_label: finalizepsbt
+description: "Syscoin Core CLI reference: finalizepsbt"
+---
+
+# `finalizepsbt`
+
+Finalize the inputs of a PSBT. If the transaction is fully signed, it will produce a
+network serialized transaction which can be broadcast with sendrawtransaction. Otherwise a PSBT will be
+created which has the final_scriptSig and final_scriptWitness fields filled for inputs that are complete.
+Implements the Finalizer and Extractor roles.
+
+## Synopsis
+
+```
+finalizepsbt "psbt" ( extract )
+```
+
+## Arguments
+
+```
+1. psbt       (string, required) A base64 string of a PSBT
+2. extract    (boolean, optional, default=true) If true and the transaction is complete,
+              extract and return the complete transaction in normal network serialization instead of the PSBT.
+```
+
+## Result
+
+```
+{                             (json object)
+  "psbt" : "str",             (string, optional) The base64-encoded partially signed transaction if not extracted
+  "hex" : "hex",              (string, optional) The hex-encoded network transaction if extracted
+  "complete" : true|false     (boolean) If the transaction has a complete set of signatures
+}
+```
+
+## Examples
+
+```
+> syscoin-cli finalizepsbt "psbt"
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/fundrawtransaction.mdx
+++ b/docs/cli/rawtransactions/fundrawtransaction.mdx
@@ -1,0 +1,126 @@
+---
+title: fundrawtransaction
+sidebar_label: fundrawtransaction
+description: "Syscoin Core CLI reference: fundrawtransaction"
+---
+
+# `fundrawtransaction`
+
+If the transaction has no inputs, they will be automatically selected to meet its out value.
+It will add at most one change output to the outputs.
+No existing outputs will be modified unless "subtractFeeFromOutputs" is specified.
+Note that inputs which were signed may need to be resigned after completion since in/outputs have been added.
+The inputs added will not be signed, use signrawtransactionwithkey
+or signrawtransactionwithwallet for that.
+All existing inputs must either have their previous output transaction be in the wallet
+or be in the UTXO set. Solving data must be provided for non-wallet inputs.
+Note that all inputs selected must be of standard form and P2SH scripts must be
+in the wallet using importaddress or addmultisigaddress (to calculate fees).
+You can see whether this is the case by checking the "solvable" field in the listunspent output.
+Only pay-to-pubkey, multisig, and P2SH versions thereof are currently supported for watch-only
+
+## Synopsis
+
+```
+fundrawtransaction "hexstring" ( options iswitness )
+```
+
+## Arguments
+
+```
+1. hexstring    (string, required) The hex string of the raw transaction
+2. options      (json object, optional) Options object that can be used to pass named arguments, listed below. For backward compatibility: passing in a true instead of an object will result in {"includeWatching":true}
+3. iswitness    (boolean, optional, default=depends on heuristic tests) Whether the transaction hex is a serialized witness transaction.
+                If iswitness is not present, heuristic tests will be used in decoding.
+                If true, only witness deserialization will be tried.
+                If false, only non-witness deserialization will be tried.
+                This boolean should reflect whether the transaction has inputs
+                (e.g. fully valid, or on-chain transactions), if known by the caller.
+
+Named Arguments:
+add_inputs                 (boolean, optional, default=true) For a transaction with existing inputs, automatically include more if they are not enough.
+include_unsafe             (boolean, optional, default=false) Include inputs that are not safe to spend (unconfirmed transactions from outside keys and unconfirmed replacement transactions).
+                           Warning: the resulting transaction may become invalid if one of the unsafe inputs disappears.
+                           If that happens, you will need to fund the transaction with different inputs and republish it.
+minconf                    (numeric, optional, default=0) If add_inputs is specified, require inputs with at least this many confirmations.
+maxconf                    (numeric, optional) If add_inputs is specified, require inputs with at most this many confirmations.
+changeAddress              (string, optional, default=automatic) The syscoin address to receive the change
+changePosition             (numeric, optional, default=random) The index of the change output
+change_type                (string, optional, default=set by -changetype) The output type to use. Only valid if changeAddress is not specified. Options are "legacy", "p2sh-segwit", "bech32", and "bech32m".
+includeWatching            (boolean, optional, default=true for watch-only wallets, otherwise false) Also select inputs which are watch only.
+                           Only solvable inputs can be used. Watch-only destinations are solvable if the public key and/or output script was imported,
+                           e.g. with 'importpubkey' or 'importmulti' with the 'pubkeys' or 'desc' field.
+lockUnspents               (boolean, optional, default=false) Lock selected unspent outputs
+fee_rate                   (numeric or string, optional, default=not set, fall back to wallet fee estimation) Specify a fee rate in sat/vB.
+feeRate                    (numeric or string, optional, default=not set, fall back to wallet fee estimation) Specify a fee rate in SYS/kvB.
+subtractFeeFromOutputs     (json array, optional, default=[]) The integers.
+                           The fee will be equally deducted from the amount of each specified output.
+                           Those recipients will receive less syscoins than you enter in their corresponding amount field.
+                           If no outputs are specified here, the sender pays the fee.
+     [
+       vout_index,         (numeric) The zero-based output index, before a change output is added.
+       ...
+     ]
+input_weights              (json array, optional) Inputs and their corresponding weights
+     [
+       {                   (json object)
+         "txid": "hex",    (string, required) The transaction id
+         "vout": n,        (numeric, required) The output index
+         "weight": n,      (numeric, required) The maximum weight for this input, including the weight of the outpoint and sequence number. Note that serialized signature sizes are not guaranteed to be consistent, so the maximum DER signatures size of 73 bytes should be used when considering ECDSA signatures.Remember to convert serialized sizes to weight units when necessary.
+       },
+       ...
+     ]
+conf_target                (numeric, optional, default=wallet -txconfirmtarget) Confirmation target in blocks
+estimate_mode              (string, optional, default="unset") The fee estimate mode, must be one of (case insensitive):
+                           "unset"
+                           "economical"
+                           "conservative"
+replaceable                (boolean, optional, default=wallet default) Marks this transaction as BIP125-replaceable.
+                           Allows this transaction to be replaced by a transaction with higher fees
+solving_data               (json object, optional) Keys and scripts needed for producing a final transaction with a dummy signature.
+                           Used for fee estimation during coin selection.
+     {
+       "pubkeys": [        (json array, optional, default=[]) Public keys involved in this transaction.
+         "pubkey",         (string) A public key
+         ...
+       ],
+       "scripts": [        (json array, optional, default=[]) Scripts involved in this transaction.
+         "script",         (string) A script
+         ...
+       ],
+       "descriptors": [    (json array, optional, default=[]) Descriptors that provide solving data for this transaction.
+         "descriptor",     (string) A descriptor
+         ...
+       ],
+     }
+```
+
+## Result
+
+```
+{                     (json object)
+  "hex" : "hex",      (string) The resulting raw transaction (hex-encoded string)
+  "fee" : n,          (numeric) Fee in SYS the resulting transaction pays
+  "changepos" : n     (numeric) The position of the added change output, or -1
+}
+```
+
+## Examples
+
+```
+Create a transaction with no inputs
+> syscoin-cli createrawtransaction "[]" "{\"myaddress\":0.01}"
+
+Add sufficient unsigned inputs to meet the output value
+> syscoin-cli fundrawtransaction "rawtransactionhex"
+
+Sign the transaction
+> syscoin-cli signrawtransactionwithwallet "fundedtransactionhex"
+
+Send the transaction
+> syscoin-cli sendrawtransaction "signedtransactionhex"
+```
+
+---
+
+*Source: [src/wallet/rpc/spend.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpc/spend.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/getrawtransaction.mdx
+++ b/docs/cli/rawtransactions/getrawtransaction.mdx
@@ -1,0 +1,47 @@
+---
+title: getrawtransaction
+sidebar_label: getrawtransaction
+description: "Syscoin Core CLI reference: getrawtransaction"
+---
+
+# `getrawtransaction`
+
+By default, this call only returns a transaction if it is in the mempool. If -txindex is enabled
+and no blockhash argument is passed, it will return the transaction if it is in the mempool or any block.
+If a blockhash argument is passed, it will return the transaction if
+the specified block is available and the transaction is in that block.
+
+Hint: Use gettransaction for wallet transactions.
+
+If verbosity is 0 or omitted, returns the serialized transaction as a hex-encoded string.
+If verbosity is 1, returns a JSON Object with information about the transaction.
+If verbosity is 2, returns a JSON Object with information about the transaction, including fee and prevout information.
+
+## Synopsis
+
+```
+getrawtransaction "txid" ( verbosity "blockhash" )
+```
+
+## Arguments
+
+```
+1. txid         (string, required) The transaction id
+2. verbosity    (numeric, optional, default=0) 0 for hex-encoded data, 1 for a JSON object, and 2 for JSON object with fee and prevout
+3. blockhash    (string, optional) The block in which to look for the transaction
+```
+
+## Examples
+
+```
+> syscoin-cli getrawtransaction "mytxid"
+> syscoin-cli getrawtransaction "mytxid" 1
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getrawtransaction", "params": ["mytxid", 1]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+> syscoin-cli getrawtransaction "mytxid" 0 "myblockhash"
+> syscoin-cli getrawtransaction "mytxid" 1 "myblockhash"
+> syscoin-cli getrawtransaction "mytxid" 2 "myblockhash"
+```
+
+---
+
+*Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/joinpsbts.mdx
+++ b/docs/cli/rawtransactions/joinpsbts.mdx
@@ -1,0 +1,42 @@
+---
+title: joinpsbts
+sidebar_label: joinpsbts
+description: "Syscoin Core CLI reference: joinpsbts"
+---
+
+# `joinpsbts`
+
+Joins multiple distinct PSBTs with different inputs and outputs into one PSBT with inputs and outputs from all of the PSBTs
+No input in any of the PSBTs can be in more than one of the PSBTs.
+
+## Synopsis
+
+```
+joinpsbts ["psbt",...]
+```
+
+## Arguments
+
+```
+1. txs            (json array, required) The base64 strings of partially signed transactions
+     [
+       "psbt",    (string, required) A base64 string of a PSBT
+       ...
+     ]
+```
+
+## Result
+
+```
+"str"    (string) The base64-encoded partially signed transaction
+```
+
+## Examples
+
+```
+> syscoin-cli joinpsbts "psbt"
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/sendrawtransaction.mdx
+++ b/docs/cli/rawtransactions/sendrawtransaction.mdx
@@ -1,0 +1,59 @@
+---
+title: sendrawtransaction
+sidebar_label: sendrawtransaction
+description: "Syscoin Core CLI reference: sendrawtransaction"
+---
+
+# `sendrawtransaction`
+
+Submit a raw transaction (serialized, hex-encoded) to local node and network.
+
+The transaction will be sent unconditionally to all peers, so using sendrawtransaction
+for manual rebroadcast may degrade privacy by leaking the transaction's origin, as
+nodes will normally not rebroadcast non-wallet transactions already in their mempool.
+
+A specific exception, RPC_TRANSACTION_ALREADY_IN_CHAIN, may throw if the transaction cannot be added to the mempool.
+
+Related RPCs: createrawtransaction, signrawtransactionwithkey
+
+## Synopsis
+
+```
+sendrawtransaction "hexstring" ( maxfeerate maxburnamount )
+```
+
+## Arguments
+
+```
+1. hexstring        (string, required) The hex string of the raw transaction
+2. maxfeerate       (numeric or string, optional, default="0.10") Reject transactions whose fee rate is higher than the specified value, expressed in SYS/kvB.
+                    Set to 0 to accept any fee rate.
+3. maxburnamount    (numeric or string, optional, default="0.00") Reject transactions with provably unspendable outputs (e.g. 'datacarrier' outputs that use the OP_RETURN opcode) greater than the specified value, expressed in SYS.
+                    If burning funds through unspendable outputs is desired, increase this value.
+                    This check is based on heuristics and does not guarantee spendability of outputs.
+```
+
+## Result
+
+```
+"hex"    (string) The transaction hash in hex
+```
+
+## Examples
+
+```
+Create a transaction
+> syscoin-cli createrawtransaction "[{\"txid\" : \"mytxid\",\"vout\":0}]" "{\"myaddress\":0.01}"
+Sign the transaction, and get back the hex
+> syscoin-cli signrawtransactionwithwallet "myhex"
+
+Send the transaction (signed hex)
+> syscoin-cli sendrawtransaction "signedhex"
+
+As a JSON-RPC call
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "sendrawtransaction", "params": ["signedhex"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mempool.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mempool.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/signrawtransactionwithkey.mdx
+++ b/docs/cli/rawtransactions/signrawtransactionwithkey.mdx
@@ -1,0 +1,84 @@
+---
+title: signrawtransactionwithkey
+sidebar_label: signrawtransactionwithkey
+description: "Syscoin Core CLI reference: signrawtransactionwithkey"
+---
+
+# `signrawtransactionwithkey`
+
+Sign inputs for raw transaction (serialized, hex-encoded).
+The second argument is an array of base58-encoded private
+keys that will be the only keys used to sign the transaction.
+The third optional argument (may be null) is an array of previous transaction outputs that
+this transaction depends on but may not yet be in the block chain.
+
+## Synopsis
+
+```
+signrawtransactionwithkey "hexstring" ["privatekey",...] ( [{"txid":"hex","vout":n,"scriptPubKey":"hex","redeemScript":"hex","witnessScript":"hex","amount":amount},...] "sighashtype" )
+```
+
+## Arguments
+
+```
+1. hexstring                        (string, required) The transaction hex string
+2. privkeys                         (json array, required) The base58-encoded private keys for signing
+     [
+       "privatekey",                (string) private key in base58-encoding
+       ...
+     ]
+3. prevtxs                          (json array, optional) The previous dependent transaction outputs
+     [
+       {                            (json object)
+         "txid": "hex",             (string, required) The transaction id
+         "vout": n,                 (numeric, required) The output number
+         "scriptPubKey": "hex",     (string, required) script key
+         "redeemScript": "hex",     (string, optional) (required for P2SH) redeem script
+         "witnessScript": "hex",    (string, optional) (required for P2WSH or P2SH-P2WSH) witness script
+         "amount": amount,          (numeric or string, optional) (required for Segwit inputs) the amount spent
+       },
+       ...
+     ]
+4. sighashtype                      (string, optional, default="DEFAULT for Taproot, ALL otherwise") The signature hash type. Must be one of:
+                                    "DEFAULT"
+                                    "ALL"
+                                    "NONE"
+                                    "SINGLE"
+                                    "ALL|ANYONECANPAY"
+                                    "NONE|ANYONECANPAY"
+                                    "SINGLE|ANYONECANPAY"
+```
+
+## Result
+
+```
+{                             (json object)
+  "hex" : "hex",              (string) The hex-encoded raw transaction with signature(s)
+  "complete" : true|false,    (boolean) If the transaction has a complete set of signatures
+  "errors" : [                (json array, optional) Script verification errors (if there are any)
+    {                         (json object)
+      "txid" : "hex",         (string) The hash of the referenced, previous transaction
+      "vout" : n,             (numeric) The index of the output to spent and used as input
+      "witness" : [           (json array)
+        "hex",                (string)
+        ...
+      ],
+      "scriptSig" : "hex",    (string) The hex-encoded signature script
+      "sequence" : n,         (numeric) Script sequence number
+      "error" : "str"         (string) Verification or signing error related to the input
+    },
+    ...
+  ]
+}
+```
+
+## Examples
+
+```
+> syscoin-cli signrawtransactionwithkey "myhex" "[\"key1\",\"key2\"]"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "signrawtransactionwithkey", "params": ["myhex", "[\"key1\",\"key2\"]"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/submitpackage.mdx
+++ b/docs/cli/rawtransactions/submitpackage.mdx
@@ -1,0 +1,67 @@
+---
+title: submitpackage
+sidebar_label: submitpackage
+description: "Syscoin Core CLI reference: submitpackage"
+---
+
+# `submitpackage`
+
+Submit a package of raw transactions (serialized, hex-encoded) to local node.
+The package must consist of a child with its parents, and none of the parents may depend on one another.
+The package will be validated according to consensus and mempool policy rules. If all transactions pass, they will be accepted to mempool.
+This RPC is experimental and the interface may be unstable. Refer to doc/policy/packages.md for documentation on package policies.
+Warning: successful submission does not mean the transactions will propagate throughout the network.
+
+## Synopsis
+
+```
+submitpackage ["rawtx",...]
+```
+
+## Arguments
+
+```
+1. package         (json array, required) An array of raw transactions.
+     [
+       "rawtx",    (string)
+       ...
+     ]
+```
+
+## Result
+
+```
+{                                   (json object)
+  "tx-results" : {                  (json object) transaction results keyed by wtxid
+    "wtxid" : {                     (json object) transaction wtxid
+      "txid" : "hex",               (string) The transaction hash in hex
+      "other-wtxid" : "hex",        (string, optional) The wtxid of a different transaction with the same txid but different witness found in the mempool. This means the submitted transaction was ignored.
+      "vsize" : n,                  (numeric) Virtual transaction size as defined in BIP 141.
+      "fees" : {                    (json object) Transaction fees
+        "base" : n,                 (numeric) transaction fee in SYS
+        "effective-feerate" : n,    (numeric, optional) if the transaction was not already in the mempool, the effective feerate in SYS per KvB. For example, the package feerate and/or feerate with modified fees from prioritisetransaction.
+        "effective-includes" : [    (json array, optional) if effective-feerate is provided, the wtxids of the transactions whose fees and vsizes are included in effective-feerate.
+          "hex",                    (string) transaction wtxid in hex
+          ...
+        ]
+      }
+    },
+    ...
+  },
+  "replaced-transactions" : [       (json array, optional) List of txids of replaced transactions
+    "hex",                          (string) The transaction id
+    ...
+  ]
+}
+```
+
+## Examples
+
+```
+> syscoin-cli testmempoolaccept [rawtx1, rawtx2]
+> syscoin-cli submitpackage [rawtx1, rawtx2]
+```
+
+---
+
+*Source: [src/rpc/mempool.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mempool.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/testmempoolaccept.mdx
+++ b/docs/cli/rawtransactions/testmempoolaccept.mdx
@@ -1,0 +1,82 @@
+---
+title: testmempoolaccept
+sidebar_label: testmempoolaccept
+description: "Syscoin Core CLI reference: testmempoolaccept"
+---
+
+# `testmempoolaccept`
+
+Returns result of mempool acceptance tests indicating if raw transaction(s) (serialized, hex-encoded) would be accepted by mempool.
+
+If multiple transactions are passed in, parents must come before children and package policies apply: the transactions cannot conflict with any mempool transactions or each other.
+
+If one transaction fails, other transactions may not be fully validated (the 'allowed' key will be blank).
+
+The maximum number of transactions allowed is 25.
+
+This checks if transactions violate the consensus or policy rules.
+
+See sendrawtransaction call.
+
+## Synopsis
+
+```
+testmempoolaccept ["rawtx",...] ( maxfeerate )
+```
+
+## Arguments
+
+```
+1. rawtxs          (json array, required) An array of hex strings of raw transactions.
+     [
+       "rawtx",    (string)
+       ...
+     ]
+2. maxfeerate      (numeric or string, optional, default="0.10") Reject transactions whose fee rate is higher than the specified value, expressed in SYS/kvB
+```
+
+## Result
+
+```
+[                                 (json array) The result of the mempool acceptance test for each raw transaction in the input array.
+                                  Returns results for each transaction in the same order they were passed in.
+                                  Transactions that cannot be fully validated due to failures in other transactions will not contain an 'allowed' result.
+                                  
+  {                               (json object)
+    "txid" : "hex",               (string) The transaction hash in hex
+    "wtxid" : "hex",              (string) The transaction witness hash in hex
+    "package-error" : "str",      (string, optional) Package validation error, if any (only possible if rawtxs had more than 1 transaction).
+    "allowed" : true|false,       (boolean, optional) Whether this tx would be accepted to the mempool and pass client-specified maxfeerate. If not present, the tx was not fully validated due to a failure in another tx in the list.
+    "vsize" : n,                  (numeric, optional) Virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted (only present when 'allowed' is true)
+    "fees" : {                    (json object, optional) Transaction fees (only present if 'allowed' is true)
+      "base" : n,                 (numeric) transaction fee in SYS
+      "effective-feerate" : n,    (numeric) the effective feerate in SYS per KvB. May differ from the base feerate if, for example, there are modified fees from prioritisetransaction or a package feerate was used.
+      "effective-includes" : [    (json array) transactions whose fees and vsizes are included in effective-feerate.
+        "hex",                    (string) transaction wtxid in hex
+        ...
+      ]
+    },
+    "reject-reason" : "str"       (string, optional) Rejection string (only present when 'allowed' is false)
+  },
+  ...
+]
+```
+
+## Examples
+
+```
+Create a transaction
+> syscoin-cli createrawtransaction "[{\"txid\" : \"mytxid\",\"vout\":0}]" "{\"myaddress\":0.01}"
+Sign the transaction, and get back the hex
+> syscoin-cli signrawtransactionwithwallet "myhex"
+
+Test acceptance of the transaction (signed hex)
+> syscoin-cli testmempoolaccept '["signedhex"]'
+
+As a JSON-RPC call
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "testmempoolaccept", "params": [["signedhex"]]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mempool.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mempool.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/rawtransactions/utxoupdatepsbt.mdx
+++ b/docs/cli/rawtransactions/utxoupdatepsbt.mdx
@@ -1,0 +1,46 @@
+---
+title: utxoupdatepsbt
+sidebar_label: utxoupdatepsbt
+description: "Syscoin Core CLI reference: utxoupdatepsbt"
+---
+
+# `utxoupdatepsbt`
+
+Updates all segwit inputs and outputs in a PSBT with data from output descriptors, the UTXO set, txindex, or the mempool.
+
+## Synopsis
+
+```
+utxoupdatepsbt "psbt" ( ["",{"desc":"str","range":n or [n,n]},...] )
+```
+
+## Arguments
+
+```
+1. psbt                          (string, required) A base64 string of a PSBT
+2. descriptors                   (json array, optional) An array of either strings or objects
+     [
+       "",                       (string) An output descriptor
+       {                         (json object) An object with an output descriptor and extra information
+         "desc": "str",          (string, required) An output descriptor
+         "range": n or [n,n],    (numeric or array, optional, default=1000) Up to what index HD chains should be explored (either end or [begin,end])
+       },
+       ...
+     ]
+```
+
+## Result
+
+```
+"str"    (string) The base64-encoded partially signed transaction with inputs updated
+```
+
+## Examples
+
+```
+> syscoin-cli utxoupdatepsbt "psbt"
+```
+
+---
+
+*Source: [src/rpc/rawtransaction.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/rawtransaction.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*


### PR DESCRIPTION
Adds 19 Rawtransactions-category RPC reference pages under
`docs/cli/rawtransactions/`, auto-generated from `syscoin-cli help`
against Syscoin Core 5.0.5.

Seventh slice of the CLI reference rollout. These are the transaction
construction primitives used by every wallet, integrator, and tooling
that builds Syscoin transactions outside the Core wallet.