### PR TITLE
docs: add auto-generated network RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/network/_category_.json
+++ b/docs/cli/network/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Network",
+  "position": 4
+}

--- a/docs/cli/network/addnode.mdx
+++ b/docs/cli/network/addnode.mdx
@@ -1,0 +1,44 @@
+---
+title: addnode
+sidebar_label: addnode
+description: "Syscoin Core CLI reference: addnode"
+---
+
+# `addnode`
+
+Attempts to add or remove a node from the addnode list.
+Or try a connection to a node once.
+Nodes added using addnode (or -connect) are protected from DoS disconnection and are not required to be
+full nodes/support SegWit as other outbound peers are (though such peers will not be synced from).
+Addnode connections are limited to 8 at a time and are counted separately from the -maxconnections limit.
+
+## Synopsis
+
+```
+addnode "node" "command" ( v2transport )
+```
+
+## Arguments
+
+```
+1. node           (string, required) The address of the peer to connect to
+2. command        (string, required) 'add' to add a node to the list, 'remove' to remove a node from the list, 'onetry' to try a connection to the node once
+3. v2transport    (boolean, optional, default=false) Attempt to connect using BIP324 v2 transport protocol (ignored for 'remove' command)
+```
+
+## Result
+
+```
+null    (json null)
+```
+
+## Examples
+
+```
+> syscoin-cli addnode "192.168.0.6:8369" "onetry" true
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "addnode", "params": ["192.168.0.6:8369", "onetry" true]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/clearbanned.mdx
+++ b/docs/cli/network/clearbanned.mdx
@@ -1,0 +1,32 @@
+---
+title: clearbanned
+sidebar_label: clearbanned
+description: "Syscoin Core CLI reference: clearbanned"
+---
+
+# `clearbanned`
+
+Clear all banned IPs.
+
+## Synopsis
+
+```
+clearbanned
+```
+
+## Result
+
+```
+null    (json null)
+```
+
+## Examples
+
+```
+> syscoin-cli clearbanned 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "clearbanned", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/disconnectnode.mdx
+++ b/docs/cli/network/disconnectnode.mdx
@@ -1,0 +1,45 @@
+---
+title: disconnectnode
+sidebar_label: disconnectnode
+description: "Syscoin Core CLI reference: disconnectnode"
+---
+
+# `disconnectnode`
+
+Immediately disconnects from the specified peer node.
+
+Strictly one out of 'address' and 'nodeid' can be provided to identify the node.
+
+To disconnect by nodeid, either set 'address' to the empty string, or call using the named 'nodeid' argument only.
+
+## Synopsis
+
+```
+disconnectnode ( "address" nodeid )
+```
+
+## Arguments
+
+```
+1. address    (string, optional, default=fallback to nodeid) The IP address/port of the node
+2. nodeid     (numeric, optional, default=fallback to address) The node ID (see getpeerinfo for node IDs)
+```
+
+## Result
+
+```
+null    (json null)
+```
+
+## Examples
+
+```
+> syscoin-cli disconnectnode "192.168.0.6:8369"
+> syscoin-cli disconnectnode "" 1
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "disconnectnode", "params": ["192.168.0.6:8369"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "disconnectnode", "params": ["", 1]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/getaddednodeinfo.mdx
+++ b/docs/cli/network/getaddednodeinfo.mdx
@@ -1,0 +1,52 @@
+---
+title: getaddednodeinfo
+sidebar_label: getaddednodeinfo
+description: "Syscoin Core CLI reference: getaddednodeinfo"
+---
+
+# `getaddednodeinfo`
+
+Returns information about the given added node, or all added nodes
+(note that onetry addnodes are not listed here)
+
+## Synopsis
+
+```
+getaddednodeinfo ( "node" )
+```
+
+## Arguments
+
+```
+1. node    (string, optional, default=all nodes) If provided, return information about this specific node, otherwise all nodes are returned.
+```
+
+## Result
+
+```
+[                                (json array)
+  {                              (json object)
+    "addednode" : "str",         (string) The node IP address or name (as provided to addnode)
+    "connected" : true|false,    (boolean) If connected
+    "addresses" : [              (json array) Only when connected = true
+      {                          (json object)
+        "address" : "str",       (string) The syscoin server IP and port we're connected to
+        "connected" : "str"      (string) connection, inbound or outbound
+      },
+      ...
+    ]
+  },
+  ...
+]
+```
+
+## Examples
+
+```
+> syscoin-cli getaddednodeinfo "192.168.0.201"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getaddednodeinfo", "params": ["192.168.0.201"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/getaddrmaninfo.mdx
+++ b/docs/cli/network/getaddrmaninfo.mdx
@@ -1,0 +1,39 @@
+---
+title: getaddrmaninfo
+sidebar_label: getaddrmaninfo
+description: "Syscoin Core CLI reference: getaddrmaninfo"
+---
+
+# `getaddrmaninfo`
+
+Provides information about the node's address manager by returning the number of addresses in the `new` and `tried` tables and their sum for all networks.
+
+## Synopsis
+
+```
+getaddrmaninfo
+```
+
+## Result
+
+```
+{                   (json object) json object with network type as keys
+  "network" : {     (json object) the network (ipv4, ipv6, onion, i2p, cjdns, all_networks)
+    "new" : n,      (numeric) number of addresses in the new table, which represent potential peers the node has discovered but hasn't yet successfully connected to.
+    "tried" : n,    (numeric) number of addresses in the tried table, which represent peers the node has successfully connected to in the past.
+    "total" : n     (numeric) total number of addresses in both new/tried tables
+  },
+  ...
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getaddrmaninfo 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getaddrmaninfo", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/getconnectioncount.mdx
+++ b/docs/cli/network/getconnectioncount.mdx
@@ -1,0 +1,32 @@
+---
+title: getconnectioncount
+sidebar_label: getconnectioncount
+description: "Syscoin Core CLI reference: getconnectioncount"
+---
+
+# `getconnectioncount`
+
+Returns the number of connections to other nodes.
+
+## Synopsis
+
+```
+getconnectioncount
+```
+
+## Result
+
+```
+n    (numeric) The connection count
+```
+
+## Examples
+
+```
+> syscoin-cli getconnectioncount 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getconnectioncount", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/getnettotals.mdx
+++ b/docs/cli/network/getnettotals.mdx
@@ -1,0 +1,45 @@
+---
+title: getnettotals
+sidebar_label: getnettotals
+description: "Syscoin Core CLI reference: getnettotals"
+---
+
+# `getnettotals`
+
+Returns information about network traffic, including bytes in, bytes out,
+and current system time.
+
+## Synopsis
+
+```
+getnettotals
+```
+
+## Result
+
+```
+{                                              (json object)
+  "totalbytesrecv" : n,                        (numeric) Total bytes received
+  "totalbytessent" : n,                        (numeric) Total bytes sent
+  "timemillis" : xxx,                          (numeric) Current system UNIX epoch time in milliseconds
+  "uploadtarget" : {                           (json object)
+    "timeframe" : n,                           (numeric) Length of the measuring timeframe in seconds
+    "target" : n,                              (numeric) Target in bytes
+    "target_reached" : true|false,             (boolean) True if target is reached
+    "serve_historical_blocks" : true|false,    (boolean) True if serving historical blocks
+    "bytes_left_in_cycle" : n,                 (numeric) Bytes left in current time cycle
+    "time_left_in_cycle" : n                   (numeric) Seconds left in current time cycle
+  }
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getnettotals 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getnettotals", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/getnetworkinfo.mdx
+++ b/docs/cli/network/getnetworkinfo.mdx
@@ -1,0 +1,71 @@
+---
+title: getnetworkinfo
+sidebar_label: getnetworkinfo
+description: "Syscoin Core CLI reference: getnetworkinfo"
+---
+
+# `getnetworkinfo`
+
+Returns an object containing various state info regarding P2P networking.
+
+## Synopsis
+
+```
+getnetworkinfo
+```
+
+## Result
+
+```
+{                                                    (json object)
+  "version" : n,                                     (numeric) the server version
+  "subversion" : "str",                              (string) the server subversion string
+  "protocolversion" : n,                             (numeric) the protocol version
+  "localservices" : "hex",                           (string) the services we offer to the network
+  "localservicesnames" : [                           (json array) the services we offer to the network, in human-readable form
+    "str",                                           (string) the service name
+    ...
+  ],
+  "localrelay" : true|false,                         (boolean) true if transaction relay is requested from peers
+  "timeoffset" : n,                                  (numeric) the time offset
+  "connections" : n,                                 (numeric) the total number of connections
+  "connections_in" : n,                              (numeric) the number of inbound connections
+  "connections_out" : n,                             (numeric) the number of outbound connections
+  "connections_mn" : n,                              (numeric) the number of verified mn connections
+  "connections_mn_in" : n,                           (numeric) the number of inbound verified mn connections
+  "connections_mn_out" : n,                          (numeric) the number of outbound verified mn connections
+  "networkactive" : true|false,                      (boolean) whether p2p networking is enabled
+  "networks" : [                                     (json array) information per network
+    {                                                (json object)
+      "name" : "str",                                (string) network (ipv4, ipv6, onion, i2p, cjdns)
+      "limited" : true|false,                        (boolean) is the network limited using -onlynet?
+      "reachable" : true|false,                      (boolean) is the network reachable?
+      "proxy" : "str",                               (string) ("host:port") the proxy that is used for this network, or empty if none
+      "proxy_randomize_credentials" : true|false     (boolean) Whether randomized credentials are used
+    },
+    ...
+  ],
+  "relayfee" : n,                                    (numeric) minimum relay fee rate for transactions in SYS/kvB
+  "incrementalfee" : n,                              (numeric) minimum fee rate increment for mempool limiting or replacement in SYS/kvB
+  "localaddresses" : [                               (json array) list of local addresses
+    {                                                (json object)
+      "address" : "str",                             (string) network address
+      "port" : n,                                    (numeric) network port
+      "score" : n                                    (numeric) relative score
+    },
+    ...
+  ],
+  "warnings" : "str"                                 (string) any network and blockchain warnings
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getnetworkinfo 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getnetworkinfo", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/getnodeaddresses.mdx
+++ b/docs/cli/network/getnodeaddresses.mdx
@@ -1,0 +1,53 @@
+---
+title: getnodeaddresses
+sidebar_label: getnodeaddresses
+description: "Syscoin Core CLI reference: getnodeaddresses"
+---
+
+# `getnodeaddresses`
+
+Return known addresses, after filtering for quality and recency.
+These can potentially be used to find new peers in the network.
+The total number of addresses known to the node may be higher.
+
+## Synopsis
+
+```
+getnodeaddresses ( count "network" )
+```
+
+## Arguments
+
+```
+1. count      (numeric, optional, default=1) The maximum number of addresses to return. Specify 0 to return all known addresses.
+2. network    (string, optional, default=all networks) Return only addresses of the specified network. Can be one of: ipv4, ipv6, onion, i2p, cjdns.
+```
+
+## Result
+
+```
+[                         (json array)
+  {                       (json object)
+    "time" : xxx,         (numeric) The UNIX epoch time when the node was last seen
+    "services" : n,       (numeric) The services offered by the node
+    "address" : "str",    (string) The address of the node
+    "port" : n,           (numeric) The port number of the node
+    "network" : "str"     (string) The network (ipv4, ipv6, onion, i2p, cjdns) the node connected through
+  },
+  ...
+]
+```
+
+## Examples
+
+```
+> syscoin-cli getnodeaddresses 8
+> syscoin-cli getnodeaddresses 4 "i2p"
+> syscoin-cli -named getnodeaddresses network=onion count=12
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getnodeaddresses", "params": [8]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getnodeaddresses", "params": [4, "i2p"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/getpeerinfo.mdx
+++ b/docs/cli/network/getpeerinfo.mdx
@@ -1,0 +1,124 @@
+---
+title: getpeerinfo
+sidebar_label: getpeerinfo
+description: "Syscoin Core CLI reference: getpeerinfo"
+---
+
+# `getpeerinfo`
+
+Returns data about each connected network peer as a json array of objects.
+
+## Synopsis
+
+```
+getpeerinfo
+```
+
+## Result
+
+```
+[                                         (json array)
+  {                                       (json object)
+    "id" : n,                             (numeric) Peer index
+    "addr" : "str",                       (string) (host:port) The IP address and port of the peer
+    "addrbind" : "str",                   (string, optional) (ip:port) Bind address of the connection to the peer
+    "addrlocal" : "str",                  (string, optional) (ip:port) Local address as reported by the peer
+    "network" : "str",                    (string) Network (ipv4, ipv6, onion, i2p, cjdns, not_publicly_routable)
+    "mapped_as" : n,                      (numeric, optional) The AS in the BGP route to the peer used for diversifying
+                                          peer selection (only available if the asmap config flag is set)
+    "services" : "hex",                   (string) The services offered
+    "verified_proregtx_hash" : "hex",     (string, optional) Only present when the peer is a masternode and successfully
+                                          authenticated via MNAUTH. In this case, this field contains the
+                                          protx hash of the masternode
+    "verified_pubkey_hash" : "hex",       (string, optional) Only present when the peer is a masternode and successfully
+                                          authenticated via MNAUTH. In this case, this field contains the
+                                          hash of the masternode's operator public key
+    "servicesnames" : [                   (json array) the services offered, in human-readable form
+      "str",                              (string) the service name if it is recognised
+      ...
+    ],
+    "relaytxes" : true|false,             (boolean) Whether we relay transactions to this peer
+    "lastsend" : xxx,                     (numeric) The UNIX epoch time of the last send
+    "lastrecv" : xxx,                     (numeric) The UNIX epoch time of the last receive
+    "last_transaction" : xxx,             (numeric) The UNIX epoch time of the last valid transaction received from this peer
+    "last_block" : xxx,                   (numeric) The UNIX epoch time of the last block received from this peer
+    "bytessent" : n,                      (numeric) The total bytes sent
+    "bytesrecv" : n,                      (numeric) The total bytes received
+    "conntime" : xxx,                     (numeric) The UNIX epoch time of the connection
+    "timeoffset" : n,                     (numeric) The time offset in seconds
+    "pingtime" : n,                       (numeric, optional) The last ping time in milliseconds (ms), if any
+    "minping" : n,                        (numeric, optional) The minimum observed ping time in milliseconds (ms), if any
+    "pingwait" : n,                       (numeric, optional) The duration in milliseconds (ms) of an outstanding ping (if non-zero)
+    "version" : n,                        (numeric) The peer version, such as 70001
+    "subver" : "str",                     (string) The string version
+    "inbound" : true|false,               (boolean) Inbound (true) or Outbound (false)
+    "bip152_hb_to" : true|false,          (boolean) Whether we selected peer as (compact blocks) high-bandwidth peer
+    "bip152_hb_from" : true|false,        (boolean) Whether peer selected us as (compact blocks) high-bandwidth peer
+    "masternode" : true|false,            (boolean) Whether connection was due to masternode connection attempt
+    "startingheight" : n,                 (numeric) The starting height (block) of the peer
+    "presynced_headers" : n,              (numeric) The current height of header pre-synchronization with this peer, or -1 if no low-work sync is in progress
+    "synced_headers" : n,                 (numeric) The last header we have in common with this peer
+    "synced_blocks" : n,                  (numeric) The last block we have in common with this peer
+    "inflight" : [                        (json array)
+      n,                                  (numeric) The heights of blocks we're currently asking from this peer
+      ...
+    ],
+    "addr_relay_enabled" : true|false,    (boolean) Whether we participate in address relay with this peer
+    "addr_processed" : n,                 (numeric) The total number of addresses processed, excluding those dropped due to rate limiting
+    "addr_rate_limited" : n,              (numeric) The total number of addresses dropped due to rate limiting
+    "permissions" : [                     (json array) Any special permissions that have been granted to this peer
+      "str",                              (string) bloomfilter (allow requesting BIP37 filtered blocks and transactions),
+                                          noban (do not ban for misbehavior; implies download),
+                                          forcerelay (relay transactions that are already in the mempool; implies relay),
+                                          relay (relay even in -blocksonly mode, and unlimited transaction announcements),
+                                          mempool (allow requesting BIP35 mempool contents),
+                                          download (allow getheaders during IBD, no disconnect after maxuploadtarget limit),
+                                          addr (responses to GETADDR avoid hitting the cache and contain random records with the most up-to-date info).
+                                          
+      ...
+    ],
+    "minfeefilter" : n,                   (numeric) The minimum fee rate for transactions this peer accepts
+    "bytessent_per_msg" : {               (json object)
+      "msg" : n,                          (numeric) The total bytes sent aggregated by message type
+                                          When a message type is not listed in this json object, the bytes sent are 0.
+                                          Only known message types can appear as keys in the object.
+      ...
+    },
+    "bytesrecv_per_msg" : {               (json object)
+      "msg" : n,                          (numeric) The total bytes received aggregated by message type
+                                          When a message type is not listed in this json object, the bytes received are 0.
+                                          Only known message types can appear as keys in the object and all bytes received
+                                          of unknown message types are listed under '*other*'.
+      ...
+    },
+    "connection_type" : "str",            (string) Type of connection: 
+                                          outbound-full-relay (default automatic connections),
+                                          block-relay-only (does not relay transactions or addresses),
+                                          inbound (initiated by the peer),
+                                          manual (added via addnode RPC or -addnode/-connect configuration options),
+                                          addr-fetch (short-lived automatic connection for soliciting addresses),
+                                          feeler (short-lived automatic connection for testing addresses).
+                                          Please note this output is unlikely to be stable in upcoming releases as we iterate to
+                                          best capture connection behaviors.
+    "transport_protocol_type" : "str",    (string) Type of transport protocol: 
+                                          detecting (peer could be v1 or v2),
+                                          v1 (plaintext transport protocol),
+                                          v2 (BIP324 encrypted transport protocol).
+                                          
+    "session_id" : "str"                  (string) The session ID for this connection, or "" if there is none ("v2" transport protocol only).
+                                          
+  },
+  ...
+]
+```
+
+## Examples
+
+```
+> syscoin-cli getpeerinfo 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getpeerinfo", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/listbanned.mdx
+++ b/docs/cli/network/listbanned.mdx
@@ -1,0 +1,41 @@
+---
+title: listbanned
+sidebar_label: listbanned
+description: "Syscoin Core CLI reference: listbanned"
+---
+
+# `listbanned`
+
+List all manually banned IPs/Subnets.
+
+## Synopsis
+
+```
+listbanned
+```
+
+## Result
+
+```
+[                              (json array)
+  {                            (json object)
+    "address" : "str",         (string) The IP/Subnet of the banned node
+    "ban_created" : xxx,       (numeric) The UNIX epoch time the ban was created
+    "banned_until" : xxx,      (numeric) The UNIX epoch time the ban expires
+    "ban_duration" : xxx,      (numeric) The ban duration, in seconds
+    "time_remaining" : xxx     (numeric) The time remaining until the ban expires, in seconds
+  },
+  ...
+]
+```
+
+## Examples
+
+```
+> syscoin-cli listbanned 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "listbanned", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/ping.mdx
+++ b/docs/cli/network/ping.mdx
@@ -1,0 +1,34 @@
+---
+title: ping
+sidebar_label: ping
+description: "Syscoin Core CLI reference: ping"
+---
+
+# `ping`
+
+Requests that a ping be sent to all other nodes, to measure ping time.
+Results provided in getpeerinfo, pingtime and pingwait fields are decimal seconds.
+Ping command is handled in queue with all other commands, so it measures processing backlog, not just network ping.
+
+## Synopsis
+
+```
+ping
+```
+
+## Result
+
+```
+null    (json null)
+```
+
+## Examples
+
+```
+> syscoin-cli ping 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "ping", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/setban.mdx
+++ b/docs/cli/network/setban.mdx
@@ -1,0 +1,42 @@
+---
+title: setban
+sidebar_label: setban
+description: "Syscoin Core CLI reference: setban"
+---
+
+# `setban`
+
+Attempts to add or remove an IP/Subnet from the banned list.
+
+## Synopsis
+
+```
+setban "subnet" "command" ( bantime absolute )
+```
+
+## Arguments
+
+```
+1. subnet      (string, required) The IP/Subnet (see getpeerinfo for nodes IP) with an optional netmask (default is /32 = single IP)
+2. command     (string, required) 'add' to add an IP/Subnet to the list, 'remove' to remove an IP/Subnet from the list
+3. bantime     (numeric, optional, default=0) time in seconds how long (or until when if [absolute] is set) the IP is banned (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)
+4. absolute    (boolean, optional, default=false) If set, the bantime must be an absolute timestamp expressed in UNIX epoch time
+```
+
+## Result
+
+```
+null    (json null)
+```
+
+## Examples
+
+```
+> syscoin-cli setban "192.168.0.6" "add" 86400
+> syscoin-cli setban "192.168.0.0/24" "add"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "setban", "params": ["192.168.0.6", "add", 86400]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/network/setnetworkactive.mdx
+++ b/docs/cli/network/setnetworkactive.mdx
@@ -1,0 +1,31 @@
+---
+title: setnetworkactive
+sidebar_label: setnetworkactive
+description: "Syscoin Core CLI reference: setnetworkactive"
+---
+
+# `setnetworkactive`
+
+Disable/enable all p2p network activity.
+
+## Synopsis
+
+```
+setnetworkactive state
+```
+
+## Arguments
+
+```
+1. state    (boolean, required) true to enable networking, false to disable
+```
+
+## Result
+
+```
+true|false    (boolean) The value that was passed in
+```
+
+---
+
+*Source: [src/rpc/net.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/net.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*


### PR DESCRIPTION
Adds 14 Network-category RPC reference pages under `docs/cli/network/`,
auto-generated from `syscoin-cli help` against Syscoin Core 5.0.5.

Eighth slice of the CLI reference rollout. These are the
peer/network/banlist RPCs used by node operators and monitoring tools.