### PR TITLE
docs: add auto-generated governance RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/governance/_category_.json
+++ b/docs/cli/governance/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Governance",
+  "position": 5
+}

--- a/docs/cli/governance/getgovernanceinfo.mdx
+++ b/docs/cli/governance/getgovernanceinfo.mdx
@@ -1,0 +1,49 @@
+---
+title: getgovernanceinfo
+sidebar_label: getgovernanceinfo
+description: "Syscoin Core CLI reference: getgovernanceinfo"
+---
+
+# `getgovernanceinfo`
+
+Returns an object containing governance parameters.
+
+## Synopsis
+
+```
+getgovernanceinfo
+```
+
+## Result
+
+```
+{                                    (json object)
+  "governanceminquorum" : n,         (numeric) The absolute minimum number of votes needed to trigger a governance action
+  "proposalfee" : n,                 (numeric) The collateral transaction fee which must be paid to create a proposal in SYS
+  "superblockcycle" : n,             (numeric) The number of blocks between superblocks
+  "superblockmaturitywindow" : n,    (numeric) the superblock trigger creation window
+  "lastsuperblock" : n,              (numeric) The block number of the last superblock
+  "nextsuperblock" : n,              (numeric) The block number of the next superblock
+  "fundingthreshold" : n,            (numeric) the number of absolute yes votes required for a proposal to be passing
+  "governancebudget" : n,            (numeric) the governance budget for the next superblock in SYS
+  "last10governancebudgets" : [      (json array)
+    {                                (json object) the last 10 governance budgets
+      "height" : n,                  (numeric) Superblock height
+      "blockhash" : "str",           (string) Superblock hash
+      "governancebudget" : n         (numeric) Superblock budget
+    },
+    ...
+  ]
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getgovernanceinfo 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getgovernanceinfo", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/getsuperblockbudget.mdx
+++ b/docs/cli/governance/getsuperblockbudget.mdx
@@ -1,0 +1,38 @@
+---
+title: getsuperblockbudget
+sidebar_label: getsuperblockbudget
+description: "Syscoin Core CLI reference: getsuperblockbudget"
+---
+
+# `getsuperblockbudget`
+
+Returns the absolute maximum sum of superblock payments allowed.
+
+## Synopsis
+
+```
+getsuperblockbudget ( index )
+```
+
+## Arguments
+
+```
+1. index    (numeric, optional) The block index
+```
+
+## Result
+
+```
+n    (numeric) The absolute maximum sum of superblock payments allowed, in SYS
+```
+
+## Examples
+
+```
+> syscoin-cli getsuperblockbudget 1000
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getsuperblockbudget", "params": [1000]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/gobject_check.mdx
+++ b/docs/cli/governance/gobject_check.mdx
@@ -1,0 +1,32 @@
+---
+title: gobject_check
+sidebar_label: gobject_check
+description: "Syscoin Core CLI reference: gobject_check"
+---
+
+# `gobject_check`
+
+Validate governance object data (proposal only)
+
+## Synopsis
+
+```
+gobject_check "hex_data"
+```
+
+## Arguments
+
+```
+1. hex_data    (string, required) Data in hex string form.
+```
+
+## Examples
+
+```
+> syscoin-cli gobject_check 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gobject_check", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/gobject_count.mdx
+++ b/docs/cli/governance/gobject_count.mdx
@@ -1,0 +1,32 @@
+---
+title: gobject_count
+sidebar_label: gobject_count
+description: "Syscoin Core CLI reference: gobject_count"
+---
+
+# `gobject_count`
+
+Count governance objects and votes
+
+## Synopsis
+
+```
+gobject_count ( "mode" )
+```
+
+## Arguments
+
+```
+1. mode    (string, optional) Output format: json ("json") or string in free form ("all").
+```
+
+## Examples
+
+```
+> syscoin-cli gobject_count json
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gobject_count", "params": [json]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/gobject_deserialize.mdx
+++ b/docs/cli/governance/gobject_deserialize.mdx
@@ -1,0 +1,32 @@
+---
+title: gobject_deserialize
+sidebar_label: gobject_deserialize
+description: "Syscoin Core CLI reference: gobject_deserialize"
+---
+
+# `gobject_deserialize`
+
+Deserialize governance object from hex string to JSON
+
+## Synopsis
+
+```
+gobject_deserialize "hex_data"
+```
+
+## Arguments
+
+```
+1. hex_data    (string, required) Data in hex string form.
+```
+
+## Examples
+
+```
+> syscoin-cli gobject_deserialize 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gobject_deserialize", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/gobject_diff.mdx
+++ b/docs/cli/governance/gobject_diff.mdx
@@ -1,0 +1,33 @@
+---
+title: gobject_diff
+sidebar_label: gobject_diff
+description: "Syscoin Core CLI reference: gobject_diff"
+---
+
+# `gobject_diff`
+
+List differences since last diff or list
+
+## Synopsis
+
+```
+gobject_diff ( "signal" "type" )
+```
+
+## Arguments
+
+```
+1. signal    (string, optional, default="valid") Cached signal, possible values: [valid|funding|delete|endorsed|all].
+2. type      (string, optional, default="all") Object type, possible values: [proposals|triggers|all].
+```
+
+## Examples
+
+```
+> syscoin-cli gobject_diff 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gobject_diff", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/gobject_get.mdx
+++ b/docs/cli/governance/gobject_get.mdx
@@ -1,0 +1,32 @@
+---
+title: gobject_get
+sidebar_label: gobject_get
+description: "Syscoin Core CLI reference: gobject_get"
+---
+
+# `gobject_get`
+
+Get governance object by hash
+
+## Synopsis
+
+```
+gobject_get "governanceHash"
+```
+
+## Arguments
+
+```
+1. governanceHash    (string, required) Object id.
+```
+
+## Examples
+
+```
+> syscoin-cli gobject_get 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gobject_get", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/gobject_getcurrentvotes.mdx
+++ b/docs/cli/governance/gobject_getcurrentvotes.mdx
@@ -1,0 +1,34 @@
+---
+title: gobject_getcurrentvotes
+sidebar_label: gobject_getcurrentvotes
+description: "Syscoin Core CLI reference: gobject_getcurrentvotes"
+---
+
+# `gobject_getcurrentvotes`
+
+Get only current (tallying) votes for a governance object hash (does not include old votes)
+
+## Synopsis
+
+```
+gobject_getcurrentvotes "governanceHash" ( "txid" vout )
+```
+
+## Arguments
+
+```
+1. governanceHash    (string, required) Object id.
+2. txid              (string, optional) Masternode collateral txid.
+3. vout              (numeric, optional) Masternode collateral output index, required if <txid> presents.
+```
+
+## Examples
+
+```
+> syscoin-cli gobject_getcurrentvotes 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gobject_getcurrentvotes", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/gobject_list.mdx
+++ b/docs/cli/governance/gobject_list.mdx
@@ -1,0 +1,33 @@
+---
+title: gobject_list
+sidebar_label: gobject_list
+description: "Syscoin Core CLI reference: gobject_list"
+---
+
+# `gobject_list`
+
+List governance objects (can be filtered by signal and/or object type)
+
+## Synopsis
+
+```
+gobject_list ( "signal" "type" )
+```
+
+## Arguments
+
+```
+1. signal    (string, optional, default="valid") Cached signal, possible values: [valid|funding|delete|endorsed|all].
+2. type      (string, optional, default="all") Object type, possible values: [proposals|triggers|all].
+```
+
+## Examples
+
+```
+> syscoin-cli gobject_list 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gobject_list", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/gobject_submit.mdx
+++ b/docs/cli/governance/gobject_submit.mdx
@@ -1,0 +1,36 @@
+---
+title: gobject_submit
+sidebar_label: gobject_submit
+description: "Syscoin Core CLI reference: gobject_submit"
+---
+
+# `gobject_submit`
+
+Submit governance object to network
+
+## Synopsis
+
+```
+gobject_submit "parentHash" revision time "dataHex" ( "feeTxid" )
+```
+
+## Arguments
+
+```
+1. parentHash    (string, required) Hash of the parent object, "0" is root.
+2. revision      (numeric, required) Object revision in the system.
+3. time          (numeric, required) Time this object was created.
+4. dataHex       (string, required) Data in hex string form.
+5. feeTxid       (string, optional) Fee-tx id, required for all objects except triggers.
+```
+
+## Examples
+
+```
+> syscoin-cli gobject_submit 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "gobject_submit", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/governance/voteraw.mdx
+++ b/docs/cli/governance/voteraw.mdx
@@ -1,0 +1,38 @@
+---
+title: voteraw
+sidebar_label: voteraw
+description: "Syscoin Core CLI reference: voteraw"
+---
+
+# `voteraw`
+
+Compile and relay a governance vote with provided external signature instead of signing vote internally
+
+## Synopsis
+
+```
+voteraw "collateralTxHash" collateralTxIndex "governanceHash" "voteSignal" "voteOutcome" time "voteSig"
+```
+
+## Arguments
+
+```
+1. collateralTxHash     (string, required) Masternode collateral txid.
+2. collateralTxIndex    (numeric, required) Masternode collateral output index.
+3. governanceHash       (string, required) Governance proposal hash.
+4. voteSignal           (string, required) One of following (funding|valid|delete|endorsed).
+5. voteOutcome          (string, required) One of following (yes|no|abstain).
+6. time                 (numeric, required) Time of vote.
+7. voteSig              (string, required) Vote signature. Must be encoded in base64.
+```
+
+## Examples
+
+```
+> syscoin-cli voteraw 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "voteraw", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/governance.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/governance.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*


### PR DESCRIPTION
Adds 11 Governance-category RPC reference pages under
`docs/cli/governance/`, auto-generated from `syscoin-cli help` against
Syscoin Core 5.0.5.

Ninth slice of the CLI reference rollout. The Governance category covers
proposal/budget queries and the gobject_* surface for inspecting
governance objects. These are Syscoin-distinctive (inherited from Dash;
no upstream Bitcoin Core equivalent), so they need local docs.