### PR TITLE
docs: add auto-generated masternode RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/masternode/_category_.json
+++ b/docs/cli/masternode/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Masternode",
+  "position": 6
+}

--- a/docs/cli/masternode/getevodbstats.mdx
+++ b/docs/cli/masternode/getevodbstats.mdx
@@ -1,0 +1,38 @@
+---
+title: getevodbstats
+sidebar_label: getevodbstats
+description: "Syscoin Core CLI reference: getevodbstats"
+---
+
+# `getevodbstats`
+
+Returns statistics about the deterministic masternode list database (DMN EvoDB).
+
+## Synopsis
+
+```
+getevodbstats
+```
+
+## Result
+
+```
+{                                     (json object)
+  "approx_persisted_entries" : n,     (numeric) Approximate number of list entries stored persistently on disk.
+  "estimated_disk_size_bytes" : n,    (numeric) Estimated total disk size occupied by the database files.
+  "cache_entries" : n,                (numeric) Number of list entries currently held in the in-memory write cache.
+  "erase_cache_entries" : n,          (numeric) Number of list entries currently marked for deletion in the in-memory erase cache.
+  "db_path" : "str"                   (string) Filesystem path to the database directory.
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getevodbstats 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getevodbstats", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_connect.mdx
+++ b/docs/cli/masternode/masternode_connect.mdx
@@ -1,0 +1,32 @@
+---
+title: masternode_connect
+sidebar_label: masternode_connect
+description: "Syscoin Core CLI reference: masternode_connect"
+---
+
+# `masternode_connect`
+
+Connect to given masternode
+
+## Synopsis
+
+```
+masternode_connect "address"
+```
+
+## Arguments
+
+```
+1. address    (string, required) The address of the masternode to connect.
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_connect 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_connect", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_count.mdx
+++ b/docs/cli/masternode/masternode_count.mdx
@@ -1,0 +1,26 @@
+---
+title: masternode_count
+sidebar_label: masternode_count
+description: "Syscoin Core CLI reference: masternode_count"
+---
+
+# `masternode_count`
+
+Get information about number of masternodes
+
+## Synopsis
+
+```
+masternode_count
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_count 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_count", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_current.mdx
+++ b/docs/cli/masternode/masternode_current.mdx
@@ -1,0 +1,26 @@
+---
+title: masternode_current
+sidebar_label: masternode_current
+description: "Syscoin Core CLI reference: masternode_current"
+---
+
+# `masternode_current`
+
+Print info on current masternode winner to be paid the next block (calculated locally)
+
+## Synopsis
+
+```
+masternode_current
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_current 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_current", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_list.mdx
+++ b/docs/cli/masternode/masternode_list.mdx
@@ -1,0 +1,53 @@
+---
+title: masternode_list
+sidebar_label: masternode_list
+description: "Syscoin Core CLI reference: masternode_list"
+---
+
+# `masternode_list`
+
+Get a list of masternodes in different modes. This call is identical to 'masternode list' call
+
+## Synopsis
+
+```
+masternode_list ( "mode" "filter" )
+```
+
+## Arguments
+
+```
+1. mode      (string, optional, default="json") The mode to run list in.
+             
+Available modes:
+             addr           - Print ip address associated with a masternode (can be additionally filtered, partial match)
+             full           - Print info in format 'status payee lastpaidtime lastpaidblock IP'
+             (can be additionally filtered, partial match)
+             info           - Print info in format 'status payee IP'
+             (can be additionally filtered, partial match)
+             json           - Print info in JSON format (can be additionally filtered, partial match)
+             lastpaidblock  - Print the last block height a node was paid on the network
+             lastpaidtime   - Print the last time a node was paid on the network
+             owneraddress   - Print the masternode owner Syscoin address
+             nevmaddress    - Print the masternode registered Syscoin NEVM address
+             payee          - Print the masternode payout Syscoin address (can be additionally filtered,
+             partial match)
+             pubKeyOperator - Print the masternode operator public key
+             status         - Print masternode status: ENABLED / POSE_BANNED
+             (can be additionally filtered, partial match)
+             votingaddress  - Print the masternode voting Syscoin address
+             
+2. filter    (string, optional) Filter results. Partial match by outpoint by default in all modes,
+             additional matches in some modes are also available.
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_list 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_list", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_outputs.mdx
+++ b/docs/cli/masternode/masternode_outputs.mdx
@@ -1,0 +1,26 @@
+---
+title: masternode_outputs
+sidebar_label: masternode_outputs
+description: "Syscoin Core CLI reference: masternode_outputs"
+---
+
+# `masternode_outputs`
+
+Print masternode compatible outputs
+
+## Synopsis
+
+```
+masternode_outputs
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_outputs 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_outputs", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/wallet/rpcmasternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/wallet/rpcmasternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_payments.mdx
+++ b/docs/cli/masternode/masternode_payments.mdx
@@ -1,0 +1,35 @@
+---
+title: masternode_payments
+sidebar_label: masternode_payments
+description: "Syscoin Core CLI reference: masternode_payments"
+---
+
+# `masternode_payments`
+
+Returns an array of deterministic masternodes and their payments for the specified block
+
+## Synopsis
+
+```
+masternode_payments ( "blockhash" count )
+```
+
+## Arguments
+
+```
+1. blockhash    (string, optional) The hash of the starting block.
+2. count        (numeric, optional) The number of blocks to return.
+                Will return <count> previous blocks if <count> is negative.
+                Both 1 and -1 correspond to the chain tip.
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_payments 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_payments", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_status.mdx
+++ b/docs/cli/masternode/masternode_status.mdx
@@ -1,0 +1,26 @@
+---
+title: masternode_status
+sidebar_label: masternode_status
+description: "Syscoin Core CLI reference: masternode_status"
+---
+
+# `masternode_status`
+
+Print masternode status outputs
+
+## Synopsis
+
+```
+masternode_status
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_status 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_status", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_winner.mdx
+++ b/docs/cli/masternode/masternode_winner.mdx
@@ -1,0 +1,26 @@
+---
+title: masternode_winner
+sidebar_label: masternode_winner
+description: "Syscoin Core CLI reference: masternode_winner"
+---
+
+# `masternode_winner`
+
+Print info on next masternode winner to vote for
+
+## Synopsis
+
+```
+masternode_winner
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_winner 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_winner", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*

--- a/docs/cli/masternode/masternode_winners.mdx
+++ b/docs/cli/masternode/masternode_winners.mdx
@@ -1,0 +1,33 @@
+---
+title: masternode_winners
+sidebar_label: masternode_winners
+description: "Syscoin Core CLI reference: masternode_winners"
+---
+
+# `masternode_winners`
+
+Print list of masternode winners
+
+## Synopsis
+
+```
+masternode_winners ( count "filter" )
+```
+
+## Arguments
+
+```
+1. count     (numeric, optional) Number of last winners to return.
+2. filter    (string, optional) Filter for returned winners.
+```
+
+## Examples
+
+```
+> syscoin-cli masternode_winners 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "masternode_winners", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/masternode.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/masternode.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-20.*


### PR DESCRIPTION
Adds 10 Masternode-category RPC reference pages under
`docs/cli/masternode/`, auto-generated from `syscoin-cli help` against
Syscoin Core 5.0.5.

Tenth slice of the CLI reference rollout. The Masternode category
contains the legacy alias-style masternode RPCs that complement the
Evo / Evowallet ProTx surface. They're directly referenced by
`docs/guides/sentrynode_setup.mdx` (e.g. `masternode_outputs`,
`masternode_status`) and are still used by tooling that predates the
ProTx workflow.