### PR TITLE
docs: add auto-generated mining RPC reference (Syscoin Core 5.0.5)

### DIFF
--- a/docs/cli/mining/_category_.json
+++ b/docs/cli/mining/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Mining",
+  "position": 7
+}

--- a/docs/cli/mining/createauxblock.mdx
+++ b/docs/cli/mining/createauxblock.mdx
@@ -1,0 +1,47 @@
+---
+title: createauxblock
+sidebar_label: createauxblock
+description: "Syscoin Core CLI reference: createauxblock"
+---
+
+# `createauxblock`
+
+Creates a new block and returns information required to merge-mine it.
+
+## Synopsis
+
+```
+createauxblock "address"
+```
+
+## Arguments
+
+```
+1. address    (string, required) Payout address for the coinbase transaction
+```
+
+## Result
+
+```
+{                                 (json object)
+  "hash" : "hex",                 (string) hash of the created block
+  "chainid" : n,                  (numeric) chain ID for this block
+  "previousblockhash" : "hex",    (string) hash of the previous block
+  "coinbasevalue" : n,            (numeric) value of the block's coinbase
+  "coinbasescript" : "hex",       (string) The full scriptPubKey of the parent coinbase output for Syscoin AuxPoW tag commitment
+  "bits" : "str",                 (string) compressed target of the block
+  "height" : n,                   (numeric) height of the block
+  "_target" : "hex"               (string) target in reversed byte order, deprecated
+}
+```
+
+## Examples
+
+```
+> syscoin-cli createauxblock "address"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "createauxblock", "params": ["address"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*

--- a/docs/cli/mining/getblocktemplate.mdx
+++ b/docs/cli/mining/getblocktemplate.mdx
@@ -1,0 +1,52 @@
+---
+title: getblocktemplate
+sidebar_label: getblocktemplate
+description: "Syscoin Core CLI reference: getblocktemplate"
+---
+
+# `getblocktemplate`
+
+If the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'.
+It returns data needed to construct a block to work on.
+For full specification, see BIPs 22, 23, 9, and 145:
+    https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki
+    https://github.com/bitcoin/bips/blob/master/bip-0023.mediawiki
+    https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki#getblocktemplate_changes
+    https://github.com/bitcoin/bips/blob/master/bip-0145.mediawiki
+
+## Synopsis
+
+```
+getblocktemplate {"mode":"str","capabilities":["str",...],"rules":["segwit","str",...],"longpollid":"str","data":"hex"}
+```
+
+## Arguments
+
+```
+1. template_request            (json object, required) Format of the template
+     {
+       "mode": "str",          (string, optional) This must be set to "template", "proposal" (see BIP 23), or omitted
+       "capabilities": [       (json array, optional) A list of strings
+         "str",                (string) client side supported feature, 'longpoll', 'coinbasevalue', 'proposal', 'serverlist', 'workid'
+         ...
+       ],
+       "rules": [              (json array, required) A list of strings
+         "segwit",             (string, required) (literal) indicates client side segwit support
+         "str",                (string) other client side supported softfork deployment
+         ...
+       ],
+       "longpollid": "str",    (string, optional) delay processing request until the result would vary significantly from the "longpollid" of a prior template
+       "data": "hex",          (string, optional) proposed block data to check, encoded in hexadecimal; valid only for mode="proposal"
+     }
+```
+
+## Examples
+
+```
+> syscoin-cli getblocktemplate '{"rules": ["segwit"]}'
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getblocktemplate", "params": [{"rules": ["segwit"]}]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*

--- a/docs/cli/mining/getmininginfo.mdx
+++ b/docs/cli/mining/getmininginfo.mdx
@@ -1,0 +1,41 @@
+---
+title: getmininginfo
+sidebar_label: getmininginfo
+description: "Syscoin Core CLI reference: getmininginfo"
+---
+
+# `getmininginfo`
+
+Returns a json object containing mining-related information.
+
+## Synopsis
+
+```
+getmininginfo
+```
+
+## Result
+
+```
+{                              (json object)
+  "blocks" : n,                (numeric) The current block
+  "currentblockweight" : n,    (numeric, optional) The block weight of the last assembled block (only present if a block was ever assembled)
+  "currentblocktx" : n,        (numeric, optional) The number of block transactions of the last assembled block (only present if a block was ever assembled)
+  "difficulty" : n,            (numeric) The current difficulty
+  "networkhashps" : n,         (numeric) The network hashes per second
+  "pooledtx" : n,              (numeric) The size of the mempool
+  "chain" : "str",             (string) current network name (main, test, regtest)
+  "warnings" : "str"           (string) any network and blockchain warnings
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getmininginfo 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getmininginfo", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*

--- a/docs/cli/mining/getnetworkhashps.mdx
+++ b/docs/cli/mining/getnetworkhashps.mdx
@@ -1,0 +1,41 @@
+---
+title: getnetworkhashps
+sidebar_label: getnetworkhashps
+description: "Syscoin Core CLI reference: getnetworkhashps"
+---
+
+# `getnetworkhashps`
+
+Returns the estimated network hashes per second based on the last n blocks.
+Pass in [blocks] to override # of blocks, -1 specifies since last difficulty change.
+Pass in [height] to estimate the network speed at the time when a certain block was found.
+
+## Synopsis
+
+```
+getnetworkhashps ( nblocks height )
+```
+
+## Arguments
+
+```
+1. nblocks    (numeric, optional, default=120) The number of blocks, or -1 for blocks since last difficulty change.
+2. height     (numeric, optional, default=-1) To estimate at the time of the given height.
+```
+
+## Result
+
+```
+n    (numeric) Hashes per second estimated
+```
+
+## Examples
+
+```
+> syscoin-cli getnetworkhashps 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getnetworkhashps", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*

--- a/docs/cli/mining/getprioritisedtransactions.mdx
+++ b/docs/cli/mining/getprioritisedtransactions.mdx
@@ -1,0 +1,38 @@
+---
+title: getprioritisedtransactions
+sidebar_label: getprioritisedtransactions
+description: "Syscoin Core CLI reference: getprioritisedtransactions"
+---
+
+# `getprioritisedtransactions`
+
+Returns a map of all user-created (see prioritisetransaction) fee deltas by txid, and whether the tx is present in mempool.
+
+## Synopsis
+
+```
+getprioritisedtransactions
+```
+
+## Result
+
+```
+{                                 (json object) prioritisation keyed by txid
+  "txid" : {                      (json object)
+    "fee_delta" : n,              (numeric) transaction fee delta in satoshis
+    "in_mempool" : true|false     (boolean) whether this transaction is currently in mempool
+  },
+  ...
+}
+```
+
+## Examples
+
+```
+> syscoin-cli getprioritisedtransactions 
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getprioritisedtransactions", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*

--- a/docs/cli/mining/prioritisetransaction.mdx
+++ b/docs/cli/mining/prioritisetransaction.mdx
@@ -1,0 +1,44 @@
+---
+title: prioritisetransaction
+sidebar_label: prioritisetransaction
+description: "Syscoin Core CLI reference: prioritisetransaction"
+---
+
+# `prioritisetransaction`
+
+Accepts the transaction into mined blocks at a higher (or lower) priority
+
+## Synopsis
+
+```
+prioritisetransaction "txid" ( dummy ) fee_delta
+```
+
+## Arguments
+
+```
+1. txid         (string, required) The transaction id.
+2. dummy        (numeric, optional) API-Compatibility for previous API. Must be zero or null.
+                DEPRECATED. For forward compatibility use named arguments and omit this parameter.
+3. fee_delta    (numeric, required) The fee value (in satoshis) to add (or subtract, if negative).
+                Note, that this value is not a fee rate. It is a value to modify absolute fee of the TX.
+                The fee is not actually paid, only the algorithm for selecting transactions into a block
+                considers the transaction as it would have paid a higher (or lower) fee.
+```
+
+## Result
+
+```
+true|false    (boolean) Returns true
+```
+
+## Examples
+
+```
+> syscoin-cli prioritisetransaction "txid" 0.0 10000
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "prioritisetransaction", "params": ["txid", 0.0, 10000]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*

--- a/docs/cli/mining/submitauxblock.mdx
+++ b/docs/cli/mining/submitauxblock.mdx
@@ -1,0 +1,39 @@
+---
+title: submitauxblock
+sidebar_label: submitauxblock
+description: "Syscoin Core CLI reference: submitauxblock"
+---
+
+# `submitauxblock`
+
+Submits a solved auxpow for a block that was previously created by 'createauxblock'.
+
+## Synopsis
+
+```
+submitauxblock "hash" "auxpow"
+```
+
+## Arguments
+
+```
+1. hash      (string, required) Hash of the block to submit
+2. auxpow    (string, required) Serialised auxpow found
+```
+
+## Result
+
+```
+true|false    (boolean) whether the submitted block was correct
+```
+
+## Examples
+
+```
+> syscoin-cli submitauxblock "hash" "serialised auxpow"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "submitauxblock", "params": ["hash" "serialised auxpow"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*

--- a/docs/cli/mining/submitblock.mdx
+++ b/docs/cli/mining/submitblock.mdx
@@ -1,0 +1,34 @@
+---
+title: submitblock
+sidebar_label: submitblock
+description: "Syscoin Core CLI reference: submitblock"
+---
+
+# `submitblock`
+
+Attempts to submit new block to network.
+See https://en.bitcoin.it/wiki/BIP_0022 for full specification.
+
+## Synopsis
+
+```
+submitblock "hexdata" ( "dummy" )
+```
+
+## Arguments
+
+```
+1. hexdata    (string, required) the hex-encoded block data to submit
+2. dummy      (string, optional, default=ignored) dummy value, for compatibility with BIP22. This value is ignored.
+```
+
+## Examples
+
+```
+> syscoin-cli submitblock "mydata"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "submitblock", "params": ["mydata"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*

--- a/docs/cli/mining/submitheader.mdx
+++ b/docs/cli/mining/submitheader.mdx
@@ -1,0 +1,39 @@
+---
+title: submitheader
+sidebar_label: submitheader
+description: "Syscoin Core CLI reference: submitheader"
+---
+
+# `submitheader`
+
+Decode the given hexdata as a header and submit it as a candidate chain tip if valid.
+Throws when the header is invalid.
+
+## Synopsis
+
+```
+submitheader "hexdata"
+```
+
+## Arguments
+
+```
+1. hexdata    (string, required) the hex-encoded block header data
+```
+
+## Result
+
+```
+null    (json null) None
+```
+
+## Examples
+
+```
+> syscoin-cli submitheader "aabbcc"
+> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "submitheader", "params": ["aabbcc"]}' -H 'content-type: text/plain;' http://127.0.0.1:8370/
+```
+
+---
+
+*Source: [src/rpc/mining.cpp](https://github.com/syscoin/syscoin/blob/master/src/rpc/mining.cpp). Auto-generated from Syscoin Core 5.0.5 on 2026-05-21.*


### PR DESCRIPTION
Adds 9 Mining-category RPC reference pages under `docs/cli/mining/`,
auto-generated from `syscoin-cli help` against Syscoin Core 5.0.5.

Eleventh slice of the CLI reference rollout. Mining covers the
block-template / block-submit lifecycle plus the AuxPoW pair that
Syscoin uses for merge-mining with Bitcoin.